### PR TITLE
fix: syntax error in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           poetry run make check
       - name: Deploy Lambdas Testnet
-        if: ${{ job.environment }} == 'testnet'
+        if: ${{ job.environment == 'testnet' }}
         run: |
           npx make deploy-lambdas-testnet
         env:
@@ -82,7 +82,7 @@ jobs:
           REDIS_DB: 0
           TOKEN_METADATA_BUCKET: token-metadata-testnet
       - name: Deploy Lambdas Mainnet
-        if: ${{ job.environment }} == 'mainnet'
+        if: ${{ job.environment == 'mainnet' }}
         run: |
           npx make deploy-lambdas-mainnet
         env:
@@ -95,13 +95,13 @@ jobs:
           REDIS_DB: 0
           TOKEN_METADATA_BUCKET: token-metadata-mainnet
       - name: Deploy Daemons Testnet
-        if: ${{ job.environment }} == 'testnet'
+        if: ${{ job.environment == 'testnet' }}
         run: |
           timestamp=`date +%s`; \
           export DOCKER_IMAGE_TAG=testnet-${{ github.sha }}-$timestamp
           make deploy-daemons
       - name: Deploy Daemons Mainnet
-        if: ${{ job.environment }} == 'mainnet'
+        if: ${{ job.environment == 'mainnet' }}
         run: |
           export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
           make deploy-daemons


### PR DESCRIPTION
Changes:
- We had a Github Actions syntax wrong for if conditionals. This is the right syntax: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#example-expression-in-an-if-conditional