### PR TITLE
chore: structured logging

### DIFF
--- a/common/configuration.py
+++ b/common/configuration.py
@@ -1,5 +1,5 @@
-from typing import Any
 from enum import Enum
+from typing import Any
 
 from decouple import Csv, config
 
@@ -34,10 +34,10 @@ class LogRenderer(Enum):
     def renderer_class(self) -> Any:
         import structlog
         class_mapping = {
-            self.JSON: structlog.processors.JSONRenderer,
-            self.CONSOLE: structlog.dev.ConsoleRenderer,
+            'json': structlog.processors.JSONRenderer,
+            'console': structlog.dev.ConsoleRenderer,
         }
-        return class_mapping[self]
+        return class_mapping[self.value]
 
     @classmethod
     def default(cls) -> 'LogRenderer':

--- a/common/configuration.py
+++ b/common/configuration.py
@@ -1,3 +1,4 @@
+from typing import Any
 from enum import Enum
 
 from decouple import Csv, config
@@ -25,6 +26,24 @@ class Environment(Enum):
         return cls.DEV
 
 
+class LogRenderer(Enum):
+    JSON = 'json'
+    CONSOLE = 'console'
+
+    @property
+    def renderer_class(self) -> Any:
+        import structlog
+        class_mapping = {
+            self.JSON: structlog.processors.JSONRenderer,
+            self.CONSOLE: structlog.dev.ConsoleRenderer,
+        }
+        return class_mapping[self]
+
+    @classmethod
+    def default(cls) -> 'LogRenderer':
+        return cls.JSON
+
+
 ENVIRONMENT = Environment(config('ENVIRONMENT', default=Environment.default().value).upper())
 
 API_PORT = config('API_PORT', default=None)
@@ -47,3 +66,5 @@ REDIS_DB = config('REDIS_DB', default='0', cast=int)
 METADATA_BUCKET = config('METADATA_BUCKET', default=None)
 
 CORS_ALLOWED_ORIGIN = config('CORS_ALLOWED_ORIGIN', default=None)
+
+LOG_RENDERER = LogRenderer(config('LOG_RENDERER', default=LogRenderer.default().value))

--- a/common/logging.py
+++ b/common/logging.py
@@ -1,0 +1,16 @@
+import structlog
+
+from common.configuration import LOG_RENDERER
+
+
+def get_logger():
+    if not structlog.is_configured():
+        processors = [
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.processors.format_exc_info,
+            LOG_RENDERER.renderer_class(),
+        ]
+        structlog.configure(processors=processors)
+    return structlog.get_logger()

--- a/poetry.lock
+++ b/poetry.lock
@@ -470,6 +470,19 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "structlog"
+version = "21.1.0"
+description = "Structured Logging for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest-randomly", "pytest (>=6.0)", "simplejson", "furo", "sphinx", "sphinx-toolbox", "twisted", "pre-commit"]
+docs = ["furo", "sphinx", "sphinx-toolbox", "twisted"]
+tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest-asyncio", "pytest-randomly", "pytest (>=6.0)", "simplejson"]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 description = "The most basic Text::Unidecode port"
@@ -537,7 +550,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "92fcd561b86746b1d69c923265f17305408aba478dbff1a19d529804574c7f6b"
+content-hash = "e75fb487bdf5af24b723fe52cc0f6885af78c75e9ce75a80de4ef8e93f25a96f"
 
 [metadata.files]
 aiohttp = [
@@ -849,6 +862,10 @@ six = [
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+structlog = [
+    {file = "structlog-21.1.0-py2.py3-none-any.whl", hash = "sha256:62f06fc0ee32fb8580f0715eea66cb87271eb7efb0eaf9af6b639cba8981de47"},
+    {file = "structlog-21.1.0.tar.gz", hash = "sha256:d9d2d890532e8db83c6977a2a676fb1889922ff0c26ad4dc0ecac26f9fafbc57"},
 ]
 text-unidecode = [
     {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ aws-lambda-context = "^1.1.0"
 python-decouple = "^3.4"
 dacite = "^1.6.0"
 requests = "^2.25.1"
+structlog = "^21.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"


### PR DESCRIPTION
# Acceptance criteria

Creates a uniform logging solution that enabled json logging (to use with cloudwatch).
Exception logs should include the traceback inside the json so the cloudwatch logs are not affected.
(Tracebacks usually are multiple lines which cloudwatch interprets as multiple logs)