### PR TITLE
fix: address api timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -155,6 +155,7 @@ functions:
   node_api_get_address_balance:
     handler: handlers/node_api.get_address_balance
     timeout: 15
+    maximumRetryAttempts: 0
     package:
       patterns:
         - 'handlers/node_api.py'
@@ -174,6 +175,7 @@ functions:
   node_api_get_address_search:
     handler: handlers/node_api.get_address_search
     timeout: 15
+    maximumRetryAttempts: 0
     package:
       patterns:
         - 'handlers/node_api.py'

--- a/serverless.yml
+++ b/serverless.yml
@@ -154,6 +154,7 @@ functions:
 
   node_api_get_address_balance:
     handler: handlers/node_api.get_address_balance
+    timeout: 15
     package:
       patterns:
         - 'handlers/node_api.py'
@@ -172,6 +173,7 @@ functions:
 
   node_api_get_address_search:
     handler: handlers/node_api.get_address_search
+    timeout: 15
     package:
       patterns:
         - 'handlers/node_api.py'


### PR DESCRIPTION
# Description

Both address APIs will make at most 3 calls to other services:
- check if address is blacklisted (timeout 2s)
- call the full-node API (timeout 10s)
- blacklist address if full-node times out (timeout 2s)

The default timeout for any lambda is 6 seconds, so the lambda will call the full-node and timeout before the API designed timeout.
The lambda will then retry this attempt to the max number of retries, always failing and putting more pressure on the full-node.

Ideally the timeout of the whole lambda would be 1 second + the combined timeout of each step (for a total of 15s).

# Acceptance criteria

- Increase the lambda timeout of both addresses APIs to 15 seconds.
- The lambda should not retry on any failure.