### PR TITLE
chore: cache time revision

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -149,6 +149,7 @@ functions:
           cors: true
           caching:
             enabled: true
+            ttlInSeconds: 10
             cacheKeyParameters:
               - name: request.querystring.id
 


### PR DESCRIPTION
# Summary

The default cache time for any handler is 5 minutes unless explicitly defined.
The cache time for the metadata api being 5 minutes makes changes take longer to be in effect and with minimal benefits.
The decision to change to 10s makes peak activity manageable and changes are noticed faster.

# Acceptance criteria

Change cache time for metadata api to 10s.