### PR TITLE
fix: lambda name > 64 char

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-explorer-service",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-explorer-service",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Hathor Explorer Service Serverless deps",
   "dependencies": {
     "serverless": "^2.44.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hathor-explorer-service"
-version = "0.1.12"
+version = "0.1.13"
 description = ""
 authors = ["Hathor Labs <contact@hathor.network>"]
 license = "MIT"

--- a/serverless.yml
+++ b/serverless.yml
@@ -234,7 +234,7 @@ functions:
               - name: request.querystring.block
               - name: request.querystring.tx
 
-  node_api_get_transaction_acc_weight:
+  node_api_get_tx_acc_w:
     handler: handlers/node_api.get_transaction_acc_weight
     maximumRetryAttempts: 0
     package:


### PR DESCRIPTION
# Summary

During testnet deploy this error occured:
```
Value 'hathor-explorer-service-testnet-node_api_get_transaction_acc_weight' at 'functionName' failed to satisfy constraint: Member must have length less than or equal to 64
```
The `hathor-explorer-service-testnet-` prefix (length 32) for testnet and `hathor-explorer-service-mainnet-` (length 32) for mainnet are added to identify the service and network of the lembda, but this leaves 32 characters for the name which `node_api_get_transaction_acc_weight` (length 35) does not fit.

# Aceeptance criteria

- Change `node_api_get_transaction_acc_weight` to a name of 32 characters or less.