### PR TITLE
fix: daemon error on status timeout

### DIFF
--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -30,6 +30,7 @@ class HathorCoreAsyncClient:
         :type domain: str, optional
         """
         self.domain = domain or HATHOR_CORE_DOMAIN
+        self.log = logger.new(client="async")
 
     async def get(self, path: str, callback: Callable[[dict], None], params: Optional[dict] = None) -> None:
         """Make a get request async
@@ -46,8 +47,14 @@ class HathorCoreAsyncClient:
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(url, params=params) as response:
+                    self.log.info(
+                        "hathor_core_response",
+                        path=path,
+                        status=response.status,
+                        body=await response.text())
                     callback(await response.json())
         except Exception as e:
+            self.log.error("hathor_core_error", path=path, error=repr(e))
             callback({'error': repr(e)})
 
 
@@ -59,6 +66,7 @@ class HathorCoreClient:
     """
     def __init__(self, domain: Optional[str] = None) -> None:
         self.domain = domain or HATHOR_CORE_DOMAIN
+        self.log = logger.new(client="sync")
 
     def get(self, path: str, params: Optional[dict] = None, **kwargs: Any) -> Optional[dict]:
         """Make a get request
@@ -77,11 +85,22 @@ class HathorCoreClient:
         try:
             response = requests.get(url, params=params, **kwargs)
             if response.status_code != 200:
-                logger.warning(f'Hathor Core Unexpected response ({response.status_code}): {response.text}')
+                self.log.warning(
+                        "hathor_core_error",
+                        path=path,
+                        status=response.status_code,
+                        body=response.text)
                 return None
+            self.log.info(
+                    "hathor_core_response",
+                    path=path,
+                    status=response.status_code,
+                    body=response.text)
 
             return response.json()
         except requests.ReadTimeout:
+            self.log.error("hathor_core_error", error="timeout", path=path)
             raise HathorCoreTimeout('timeout')
         except Exception as e:
+            self.log.error("hathor_core_error", error=repr(e), path=path)
             return {'error': repr(e)}


### PR DESCRIPTION
# Summary

During some calls the node would timeout the response (with status 504), or return a status 429 and although aiohttp does not raise an exception for this it does raise when trying to read a json from a mime-type html response (which is the case on both errors).
The error treatment of the HathorCoreAsyncClient is to send the error to the callback, but the callback for the daemon does not have an error treatment.

# Acceptance criteria

- Ignore errors when collecting node status
- Log responses and errors from hathor core to make errors like this easier to spot