### PR TITLE
feat: remove unused tokens API

### DIFF
--- a/gateways/node_api_gateway.py
+++ b/gateways/node_api_gateway.py
@@ -168,8 +168,3 @@ class NodeApiGateway:
         """Retrieve token by id
         """
         return self.hathor_core_client.get(TOKEN_ENDPOINT, params={'id': id})
-
-    def list_tokens(self) -> Optional[dict]:
-        """Retrieve list of tokens
-        """
-        return self.hathor_core_client.get(TOKEN_ENDPOINT)

--- a/handlers/node_api.py
+++ b/handlers/node_api.py
@@ -275,27 +275,6 @@ def get_token(
 
 
 @ApiGateway()
-def list_tokens(
-    event: ApiGatewayEvent,
-    _context: LambdaContext,
-    node_api: Optional[NodeApi] = None
-) -> dict:
-    """Get a list of tokens with details.
-
-        *IMPORTANT: Any changes on the parameters should be reflected on the `cacheKeyParameters` for this method.
-    """
-    node_api = node_api or NodeApi()
-    response = node_api.list_tokens()
-    return {
-        "statusCode": 200,
-        "body": json.dumps(response or {}),
-        "headers": {
-            "Content-Type": "application/json"
-        }
-    }
-
-
-@ApiGateway()
 def decode_tx(
     event: ApiGatewayEvent,
     _context: LambdaContext,

--- a/serverless.yml
+++ b/serverless.yml
@@ -337,23 +337,6 @@ functions:
             cacheKeyParameters:
               - name: request.querystring.id
 
-  node_api_list_tokens:
-    handler: handlers/node_api.list_tokens
-    maximumRetryAttempts: 0
-    package:
-      patterns:
-        - 'handlers/node_api.py'
-    layers:
-      - { Ref: PythonRequirementsLambdaLayer }
-    events:
-      - http:
-          path: node_api/tokens
-          method: get
-          cors: true
-          caching:
-            enabled: true
-            ttlInSeconds: 3600
-
   node_api_decode_tx:
     handler: handlers/node_api.decode_tx
     maximumRetryAttempts: 0

--- a/tests/unit/gateways/test_node_api_gateway.py
+++ b/tests/unit/gateways/test_node_api_gateway.py
@@ -206,16 +206,6 @@ class TestNodeApiGateway:
         assert result
         assert sorted(result) == sorted(obj)
 
-    @patch('gateways.node_api_gateway.TOKEN_ENDPOINT', 'mock-endpoint')
-    def test_list_tokens(self, hathor_client):
-        obj = {'foo': 'bar'}
-        hathor_client.get = MagicMock(return_value=obj)
-        gateway = NodeApiGateway(hathor_core_client=hathor_client)
-        result = gateway.list_tokens()
-        hathor_client.get.assert_called_once_with('mock-endpoint')
-        assert result
-        assert sorted(result) == sorted(obj)
-
     @patch('gateways.node_api_gateway.DECODE_TX_ENDPOINT', 'mock-endpoint')
     def test_decode_tx(self, hathor_client):
         obj = {'foo': 'bar'}

--- a/tests/unit/usecases/test_node_api.py
+++ b/tests/unit/usecases/test_node_api.py
@@ -245,15 +245,6 @@ class TestNodeApiCommon:
         assert result
         assert sorted(result) == sorted(obj)
 
-    def test_list_tokens(self, node_api_gateway):
-        obj = {"foo": "bar"}
-        node_api_gateway.list_tokens = MagicMock(return_value=obj)
-        node_api = NodeApi(node_api_gateway)
-        result = node_api.list_tokens()
-        node_api_gateway.list_tokens.assert_called_once()
-        assert result
-        assert sorted(result) == sorted(obj)
-
     def test_decode_tx(self, node_api_gateway):
         obj = {"foo": "bar"}
         node_api_gateway.decode_tx = MagicMock(return_value=obj)

--- a/usecases/node_api.py
+++ b/usecases/node_api.py
@@ -83,6 +83,3 @@ class NodeApi:
 
     def get_token(self, id: str) -> Optional[dict]:
         return self.node_api_gateway.get_token(id)
-
-    def list_tokens(self) -> Optional[dict]:
-        return self.node_api_gateway.list_tokens()


### PR DESCRIPTION
### Motivation

Since [this PR](https://github.com/HathorNetwork/hathor-explorer/pull/154) was merged, tokens API is not being used anymore, so we are removing it. A new token API will be designed as part of [this issue](https://github.com/HathorNetwork/hathor-explorer-service/issues/73).

It solves issue #111

### Acceptance Criteria

Hathor Explorer must continue to work without any UI modification, especially when listing tokens in a transaction or showing token info. This video demonstrates this (This test was performed on my local environment pointing to testnet):

https://user-images.githubusercontent.com/3287486/152403428-84f58790-febf-4ac2-b3ac-f259a577d373.mov


