### PR TITLE
fix: avoid alerting on missing data

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -85,6 +85,7 @@ custom:
         period: 60
         evaluationPeriods: 5
         comparisonOperator: GreaterThanOrEqualToThreshold
+        treatMissingData: notBreaching
         okActions:
           - major
         alarmActions:
@@ -97,6 +98,7 @@ custom:
         period: 60
         evaluationPeriods: 1
         comparisonOperator: GreaterThanOrEqualToThreshold
+        treatMissingData: notBreaching
         okActions:
           - minor
         alarmActions:


### PR DESCRIPTION
### Acceptance Criteria
We should not alert in case of missing data in the CloudWatch alarms created for the Lambdas.

This behavior was observed in other projects with similar alarms, and this will avoid the same thing from happening here.

Reference:
https://www.serverless.com/plugins/serverless-plugin-aws-alerts
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data