### PR TITLE
Fix CORS problem due to API GW caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ First, rename `.env.example` file to `.env`. You can do that by running `cp .env
 Then, run `docker-compose up -d` to enable explorer-service, Redis, and daemons locally.
 
 Explorer service will be exposed on port 3001.
+
+## Adding a new API
+
+If you add a new API, be careful to add ```request.header.origin``` as cacheKey, if applicable. Otherwise, you may see CORS error when accessing the same resource from different domains.

--- a/serverless.yml
+++ b/serverless.yml
@@ -260,6 +260,8 @@ functions:
           caching:
             enabled: true
             ttlInSeconds: 3600
+            cacheKeyParameters:
+              - name: request.header.Origin
 
   node_api_get_dashboard_tx:
     handler: handlers/node_api.get_dashboard_tx

--- a/serverless.yml
+++ b/serverless.yml
@@ -125,6 +125,9 @@ functions:
             parameters:
               paths:
                 hash: true
+          caching:
+            cacheKeyParameters:
+              - name: request.header.origin
 
   list_nodes_handler:
     handler: handlers/list_nodes_handler.handle
@@ -138,6 +141,9 @@ functions:
           path: node/
           method: get
           cors: true
+          caching:
+            cacheKeyParameters:
+              - name: request.header.origin
 
   get_network_handler:
     handler: handlers/get_network_handler.handle
@@ -151,6 +157,9 @@ functions:
           path: network/
           method: get
           cors: true
+          caching:
+            cacheKeyParameters:
+              - name: request.header.origin
 
   node_data_aggregator_handler:
     handler: handlers/node_data_aggregator.handle
@@ -181,6 +190,7 @@ functions:
             ttlInSeconds: 15
             cacheKeyParameters:
               - name: request.path.hash
+              - name: request.header.origin
 
   get_dag_metadata_handler:
     handler: handlers/get_dag_metadata_handler.handle
@@ -199,6 +209,7 @@ functions:
             ttlInSeconds: 10
             cacheKeyParameters:
               - name: request.querystring.id
+              - name: request.header.origin
 
   node_api_get_address_balance:
     handler: handlers/node_api.get_address_balance
@@ -219,6 +230,7 @@ functions:
             ttlInSeconds: 300
             cacheKeyParameters:
               - name: request.querystring.address
+              - name: request.header.origin
 
   node_api_get_address_search:
     handler: handlers/node_api.get_address_search
@@ -243,6 +255,7 @@ functions:
               - name: request.querystring.token
               - name: request.querystring.page
               - name: request.querystring.hash
+              - name: request.header.origin
 
   node_api_get_version:
     handler: handlers/node_api.get_version
@@ -261,7 +274,7 @@ functions:
             enabled: true
             ttlInSeconds: 3600
             cacheKeyParameters:
-              - name: request.header.Origin
+              - name: request.header.origin
 
   node_api_get_dashboard_tx:
     handler: handlers/node_api.get_dashboard_tx
@@ -282,6 +295,7 @@ functions:
             cacheKeyParameters:
               - name: request.querystring.block
               - name: request.querystring.tx
+              - name: request.header.origin
 
   node_api_get_tx_acc_w:
     handler: handlers/node_api.get_transaction_acc_weight
@@ -301,6 +315,7 @@ functions:
             ttlInSeconds: 5
             cacheKeyParameters:
               - name: request.querystring.id
+              - name: request.header.origin
 
   node_api_get_token_history:
     handler: handlers/node_api.get_token_history
@@ -324,6 +339,7 @@ functions:
               - name: request.querystring.hash
               - name: request.querystring.page
               - name: request.querystring.timestamp
+              - name: request.header.origin
 
   node_api_get_transaction:
     handler: handlers/node_api.get_transaction
@@ -343,6 +359,7 @@ functions:
             ttlInSeconds: 10
             cacheKeyParameters:
               - name: request.querystring.id
+              - name: request.header.origin
 
   node_api_list_transactions:
     handler: handlers/node_api.list_transactions
@@ -366,6 +383,7 @@ functions:
               - name: request.querystring.hash
               - name: request.querystring.page
               - name: request.querystring.timestamp
+              - name: request.header.origin
 
   node_api_get_token:
     handler: handlers/node_api.get_token
@@ -385,6 +403,7 @@ functions:
             ttlInSeconds: 10
             cacheKeyParameters:
               - name: request.querystring.id
+              - name: request.header.origin
 
   node_api_decode_tx:
     handler: handlers/node_api.decode_tx
@@ -404,6 +423,7 @@ functions:
             ttlInSeconds: 300
             cacheKeyParameters:
               - name: request.querystring.hex_tx
+              - name: request.header.origin
 
   node_api_push_tx:
     handler: handlers/node_api.push_tx
@@ -423,6 +443,7 @@ functions:
             ttlInSeconds: 5
             cacheKeyParameters:
               - name: request.querystring.hex_tx
+              - name: request.header.origin
 
   node_api_gviz_dot_neighbors:
     handler: handlers/node_api.graphviz_dot_neighbors
@@ -444,3 +465,4 @@ functions:
               - name: request.querystring.tx
               - name: request.querystring.graph_type
               - name: request.querystring.max_level
+              - name: request.header.origin

--- a/serverless.yml
+++ b/serverless.yml
@@ -125,9 +125,6 @@ functions:
             parameters:
               paths:
                 hash: true
-          caching:
-            cacheKeyParameters:
-              - name: request.header.origin
 
   list_nodes_handler:
     handler: handlers/list_nodes_handler.handle
@@ -141,9 +138,6 @@ functions:
           path: node/
           method: get
           cors: true
-          caching:
-            cacheKeyParameters:
-              - name: request.header.origin
 
   get_network_handler:
     handler: handlers/get_network_handler.handle
@@ -157,9 +151,6 @@ functions:
           path: network/
           method: get
           cors: true
-          caching:
-            cacheKeyParameters:
-              - name: request.header.origin
 
   node_data_aggregator_handler:
     handler: handlers/node_data_aggregator.handle


### PR DESCRIPTION
### Description

If the user access ```https://explorer.hathor.network```, it will work normally. However, if after that the user tries to access ```https://explorer.mainnet.hathor.network``` he/she will see a CORS problem. This happens because the first request is cached and returned on the second request. The browser identifies that the ```Origin``` in the request is different than the ```Access-Control-Allow-Origin``` in the response and shows the CORS error message to the user.

To solve that, the ```Origin``` was introduced as a cache key on ```node_api_get_version``` endpoint, which is the API that is returning CORS error.

### Testing

Tests were performed using Postman and deploying a local stack of Explorer Service on AWS. Now, when the origin changes (And matches the Regex), the ```Access-Control-Allow-Origin``` returns the correct value.

### Acceptance criteria

User must not see CORS error message on any domain that matches the regex.