### PR TITLE
chore: stop diff early

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,4 @@ deploy-daemons:
 
 .PHONY: run
 run:
-	docker-compose up -d
-	npx serverless offline --printOutput
+	docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,19 @@ services:
   daemons:
     build:
       context: .
-      dockerfile: Dockerfile_Daemons 
+      dockerfile: Dockerfile_Daemons
     stdin_open: true
     env_file:
       - .env
   redis:
     image: "redis:6-alpine"
-    ports: 
+    ports:
       - 6379:6379
   explorer-service:
     build:
       context: .
       dockerfile: Dockerfile_Service
-    ports: 
+    ports:
       - 3001:3001
       - 3002:3002
       - 4569:4569

--- a/poetry.lock
+++ b/poetry.lock
@@ -149,7 +149,7 @@ dev = ["pytest (>=5)", "pytest-cov", "coveralls", "black", "mypy", "pylint"]
 
 [[package]]
 name = "deepdiff"
-version = "5.5.0"
+version = "5.7.0"
 description = "Deep Difference and Search of any Python object/data."
 category = "main"
 optional = false
@@ -159,7 +159,7 @@ python-versions = ">=3.6"
 ordered-set = "4.0.2"
 
 [package.extras]
-cli = ["click (==7.1.2)", "pyyaml (==5.4)", "toml (==0.10.2)", "clevercsv (==0.6.7)"]
+cli = ["click (==8.0.3)", "pyyaml (==5.4.1)", "toml (==0.10.2)", "clevercsv (==0.7.1)"]
 
 [[package]]
 name = "factory-boy"
@@ -720,8 +720,8 @@ dacite = [
     {file = "dacite-1.6.0.tar.gz", hash = "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"},
 ]
 deepdiff = [
-    {file = "deepdiff-5.5.0-py3-none-any.whl", hash = "sha256:e054fed9dfe0d83d622921cbb3a3d0b3a6dd76acd2b6955433a0a2d35147774a"},
-    {file = "deepdiff-5.5.0.tar.gz", hash = "sha256:dd79b81c2d84bfa33aa9d94d456b037b68daff6bb87b80dfaa1eca04da68b349"},
+    {file = "deepdiff-5.7.0-py3-none-any.whl", hash = "sha256:1ffb38c3b5d9174eb2df95850c93aee55ec00e19396925036a2e680f725079e0"},
+    {file = "deepdiff-5.7.0.tar.gz", hash = "sha256:838766484e323dcd9dec6955926a893a83767dc3f3f94542773e6aa096efe5d4"},
 ]
 factory-boy = [
     {file = "factory_boy-3.2.0-py2.py3-none-any.whl", hash = "sha256:1d3db4b44b8c8c54cdd8b83ae4bdb9aeb121e464400035f1f03ae0e1eade56a4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python-decouple = "^3.4"
 dacite = "^1.6.0"
 requests = "^2.25.1"
 structlog = "^21.1.0"
-deepdiff = "^5.5.0"
+deepdiff = "^5.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/serverless.yml
+++ b/serverless.yml
@@ -154,6 +154,7 @@ functions:
 
   node_data_aggregator_handler:
     handler: handlers/node_data_aggregator.handle
+    timeout: 30
     package:
       patterns:
         - 'handlers/node_data_aggregator.py'

--- a/tests/unit/usecases/test_aggregate_node_data.py
+++ b/tests/unit/usecases/test_aggregate_node_data.py
@@ -1,10 +1,47 @@
 from unittest.mock import MagicMock
 
 from pytest import fixture
+from deepdiff import DeepDiff
 
 from domain.network.network import Network
 from tests.fixtures.network_factory import NetworkFactory
-from usecases.aggregate_node_data import AggregateNodeData
+from usecases.aggregate_node_data import AggregateNodeData, EarlyStopDiff
+
+
+class TestEarlyStopDiff:
+
+    def test_multiple_diffs(self):
+        data11 = {'a': 1, 'b': 2}
+        data12 = {'a': 3, 'b': 4}
+        diff1 = DeepDiff(data11, data12, custom_operators=[EarlyStopDiff()])
+        # On the diff tree each key represents a type of modification (e.g. values_changed, dictionary_item_removed)
+        # Each value is a list of differences of this type
+        # Assert having 1 difference in all types (when we have more than 1) means we stopped when we found the first
+        print(diff1)
+        assert sum(len(v) for v in diff1.tree.values()) == 1
+
+        data21 = {'a': 1, 'b': 1}
+        data22 = {'b': 2, 'c': 1, 'd': 1}
+        diff2 = DeepDiff(data21, data22, custom_operators=[EarlyStopDiff()])
+        # The only instance where we would have more than 1 difference is when we remove or add a key
+        # Then it's 1 for each removed or added key, ignoring changes on values
+        print(diff2)
+        assert sum(len(v) for v in diff2.tree.values()) == 3
+
+        data31 = {'foo': {'a': 1, 'b': 2}, 'foz': {'some': 'thing'}}
+        data32 = {'foo': {'a': 2, 'b': 2}, 'foz': {'to': 'change'}}
+        diff3 = DeepDiff(data31, data32, custom_operators=[EarlyStopDiff()])
+        # DFS on ordered keys means we wont check 'foz' since we found a diff on a subkey of 'foo'
+        print(diff3)
+        assert sum(len(v) for v in diff3.tree.values()) == 1
+
+        data41 = {'foo': {'a': 1, 'b': 2}, 'foz': {'some': 'thing'}}
+        data42 = {'foo': {'a': 1, 'b': 2}, 'foz': {'to': 'change'}}
+        diff4 = DeepDiff(data41, data42, custom_operators=[EarlyStopDiff()])
+        # It also means we will check on 'foz' if we dont find diffs on 'foo'
+        print(diff4)
+        assert sum(len(v) for v in diff4.tree.values()) == 2
+
 
 
 class TestAggregateNodeData:

--- a/tests/unit/usecases/test_aggregate_node_data.py
+++ b/tests/unit/usecases/test_aggregate_node_data.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
-from pytest import fixture
 from deepdiff import DeepDiff
+from pytest import fixture
 
 from domain.network.network import Network
 from tests.fixtures.network_factory import NetworkFactory
@@ -41,7 +41,6 @@ class TestEarlyStopDiff:
         # It also means we will check on 'foz' if we dont find diffs on 'foo'
         print(diff4)
         assert sum(len(v) for v in diff4.tree.values()) == 2
-
 
 
 class TestAggregateNodeData:

--- a/usecases/aggregate_node_data.py
+++ b/usecases/aggregate_node_data.py
@@ -1,12 +1,25 @@
 from typing import Union
 
 from deepdiff import DeepDiff
+from deepdiff.model import DiffLevel
 
 from gateways.node_gateway import NodeGateway
 
 
-class AggregateNodeData:
+class EarlyStopDiff:
+    """ Stop the diff when we find an error
 
+    From the docs example at:
+    https://zepworks.com/deepdiff/5.7.0/custom.html#custom-operators
+    """
+    def match(self, level: DiffLevel) -> bool:
+        return True
+
+    def give_up_diffing(self, level: DiffLevel, diff_instance: DeepDiff) -> bool:
+        return any(diff_instance.tree.values())
+
+
+class AggregateNodeData:
     def __init__(self, node_gateway: Union[NodeGateway, None] = None) -> None:
         self.node_gateway = node_gateway or NodeGateway()
 
@@ -18,7 +31,8 @@ class AggregateNodeData:
             regex_path_to_exclude = r"root\['(nodes|peers)'\]\[\d+\]\['uptime'\]"
             new_dict = new_network.to_dict()
             old_dict = old_network.to_dict()
-            networks_diff = DeepDiff(new_dict, old_dict, ignore_order=True, exclude_regex_paths=regex_path_to_exclude)
+            networks_diff = DeepDiff(new_dict, old_dict, ignore_order=True, exclude_regex_paths=regex_path_to_exclude,
+                                     custom_operators=[EarlyStopDiff()])
 
         if (not old_network) or networks_diff:
             return self.node_gateway.save_network(new_network)

--- a/usecases/aggregate_node_data.py
+++ b/usecases/aggregate_node_data.py
@@ -1,9 +1,13 @@
 from typing import Union
+from time import time
 
 from deepdiff import DeepDiff
 from deepdiff.model import DiffLevel
 
+from common.logging import get_logger
 from gateways.node_gateway import NodeGateway
+
+logger = get_logger()
 
 
 class EarlyStopDiff:
@@ -22,10 +26,16 @@ class EarlyStopDiff:
 class AggregateNodeData:
     def __init__(self, node_gateway: Union[NodeGateway, None] = None) -> None:
         self.node_gateway = node_gateway or NodeGateway()
+        self.log = logger.new()
 
     def aggregate(self) -> Union[bool, None]:
+        begin = time()
         new_network = self.node_gateway.aggregate_network()
+        agg_time = time()
+        self.log.info('data_aggregator_ts', segment='agg_new_network', time=agg_time - begin)
         old_network = self.node_gateway.get_network()
+        read_time = time()
+        self.log.info('data_aggregator_ts', segment='read_old_network', time=read_time - agg_time)
 
         if old_network:
             regex_path_to_exclude = r"root\['(nodes|peers)'\]\[\d+\]\['uptime'\]"
@@ -33,6 +43,8 @@ class AggregateNodeData:
             old_dict = old_network.to_dict()
             networks_diff = DeepDiff(new_dict, old_dict, ignore_order=True, exclude_regex_paths=regex_path_to_exclude,
                                      custom_operators=[EarlyStopDiff()])
+            diff_time = time()
+            self.log.info('data_aggregator_ts', segment='diff_network', time=diff_time - read_time)
 
         if (not old_network) or networks_diff:
             return self.node_gateway.save_network(new_network)

--- a/usecases/aggregate_node_data.py
+++ b/usecases/aggregate_node_data.py
@@ -1,5 +1,5 @@
-from typing import Union
 from time import time
+from typing import Union
 
 from deepdiff import DeepDiff
 from deepdiff.model import DiffLevel


### PR DESCRIPTION
# Summary

On the data aggregator lambda, the [deepdiff](https://github.com/seperman/deepdiff) lib is used to check if there is any difference between the network data that was aggregated and the one saved on cache. If there is a difference we save the most recent one.

The network data is aggregated from node statuses of the nodes, and some reach over 32Kb of data (after filtering unnecessary data, before filtering it would be over 1Mb) this makes the deepdiff take more time to find all differences on every request.

The proposed solution is to stop the deepdiff when it finds the first difference.

# Acceptance criteria

- [x] Stop the deepdiff of the network data aggregator when it finds the first difference.
- [x] Increase the data aggregator lambda timeout
- [x] Log where needed for better understanding when a lambda timeout occurs
