### PR TITLE
feat: add throttling to tokens api

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "serverless": "^2.44.0",
     "serverless-api-gateway-caching": "^1.7.2",
-    "serverless-plugin-aws-alerts": "^1.7.4"
+    "serverless-plugin-aws-alerts": "^1.7.4",
+    "serverless-api-gateway-throttling": "^1.2.2"
   },
   "devDependencies": {
     "serverless-python-requirements": "^5.1.1",

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,6 +42,7 @@ plugins:
   - serverless-python-requirements
   - serverless-api-gateway-caching
   - serverless-plugin-aws-alerts
+  - serverless-api-gateway-throttling
 
 package:
   individually: true
@@ -212,6 +213,9 @@ functions:
               - name: request.querystring.order
               - name: request.querystring.search_after
               - name: request.header.origin
+          throttling:
+            maxRequestsPerSecond: 1000
+            maxConcurrentRequests: 1000
 
   get_dag_metadata_handler:
     handler: handlers/get_dag_metadata_handler.handle

--- a/serverless.yml
+++ b/serverless.yml
@@ -68,6 +68,11 @@ custom:
   apiGatewayCaching:
     enabled: true
     ttlInSeconds: 300
+  apiGatewayThrottling:
+    # Apply to all http endpoints, unless overridden
+    # According to AWS: "Each method in this stage will respect these rate and burst settings."
+    maxRequestsPerSecond: 50
+    maxConcurrentRequests: 25
   alerts:
     stages: # Select which stages to deploy alarms to
       - mainnet
@@ -213,9 +218,6 @@ functions:
               - name: request.querystring.order
               - name: request.querystring.search_after
               - name: request.header.origin
-          throttling:
-            maxRequestsPerSecond: 1000
-            maxConcurrentRequests: 1000
 
   get_dag_metadata_handler:
     handler: handlers/get_dag_metadata_handler.handle


### PR DESCRIPTION
### Acceptance Criteria

Throttle tokens API to prevent resource exhaustion

The throttle values were created based on the traffic that was observed on Transactions API.
