### PR TITLE
chore: enable API Gateway logs

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,9 @@ provider:
   runtime: python3.8
   region: ${env:AWS_DEFAULT_REGION}
   lambdaHashingVersion: 20201221
+  logs:
+    restApi:
+      role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch
   vpc:
     securityGroupIds:
       - ${env:AWS_VPC_DEFAULT_SG_ID}


### PR DESCRIPTION
### Acceptance Criteria
- We should have logs for API Gateway

### Motivation
I observed a high number of 4xx requests in the API Gateway monitoring, but couldn't find the reason.

### Reference:
- Creating a role for API Gateway logging: https://aws.amazon.com/premiumsupport/knowledge-center/api-gateway-cloudwatch-logs/

- Serverless reference: https://www.serverless.com/framework/docs/providers/aws/events/apigateway#logs