### PR TITLE
fix: reduce endpoint name

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -195,7 +195,7 @@ functions:
               - name: request.path.hash
               - name: request.header.origin
 
-  get_token_balances_handler:
+  get_tokenbalances_handler:
     handler: handlers/token_balance_api.get_token_balances
     timeout: 6
     maximumRetryAttempts: 0
@@ -219,7 +219,7 @@ functions:
               - name: request.querystring.search_after
               - name: request.header.origin
 
-  get_token_balance_information_handler:
+  get_tokenbalance_info_handler:
     handler: handlers/token_balance_api.get_token_information
     timeout: 6
     maximumRetryAttempts: 0


### PR DESCRIPTION
### Acceptance Criteria

[Testnet deployment](https://github.com/HathorNetwork/hathor-explorer-service/runs/6891747988?check_suite_focus=true) failed because the definition of the `get_token_balances_handler` endpoint on serverless.yml is too long.

It seems that an `_` takes 11 characters (The string `Underscore`), so I prioritized removing this character.

This PR should reduce `get_token_balances_handler` from  74 to 57 characters. 64 is the maximum allowed.

