### PR TITLE
fix: typo on querystring of cacheKeyParameters

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -213,7 +213,7 @@ functions:
             enabled: true
             ttlInSeconds: 300
             cacheKeyParameters:
-              - name: request.queryString.token_id
+              - name: request.querystring.token_id
               - name: request.querystring.sort_by
               - name: request.querystring.order
               - name: request.querystring.search_after


### PR DESCRIPTION
### Acceptance Criteria

[Deploy is failing](https://github.com/HathorNetwork/hathor-explorer-service/runs/6905130392?check_suite_focus=true) because of a typo on a `cacheKeyParameter` of  `get_tokenbalances_handler` API.

I checked and this is the only typo on `cacheKeyParameters`.