### PR TITLE
feat: get token by token_id API and add transactions count to token return

### DIFF
--- a/gateways/token_api_gateway.py
+++ b/gateways/token_api_gateway.py
@@ -2,8 +2,9 @@ from typing import List, Optional
 
 from elasticsearch import Elasticsearch
 
-from common.configuration import ELASTIC_INDEX
+from common.configuration import ELASTIC_INDEX, ELASTIC_SEARCH_TIMEOUT
 from gateways.clients.elastic_search_client import ElasticSearchClient
+from utils.elastic_search.elastic_search_utils import ElasticSearchUtils
 
 
 class TokenApiGateway:
@@ -22,3 +23,20 @@ class TokenApiGateway:
         """Retrieve all tokens that match user's query
         """
         return self.elastic_search_client.make_query(search_text, sort_by, order, search_after)
+
+    def get_token(self, token_id: str) -> dict:
+        """Retrieve a specific token given its token_id
+        """
+        elastic_search_utils = ElasticSearchUtils(elastic_index=ELASTIC_INDEX)
+
+        body = {
+            'size': 1,
+            'request_timeout': int(ELASTIC_SEARCH_TIMEOUT),
+            'query': {
+                'id': token_id,
+            }
+        }
+
+        response = self.elastic_search_client.run(body)
+
+        return elastic_search_utils.treat_response(response)

--- a/gateways/token_api_gateway.py
+++ b/gateways/token_api_gateway.py
@@ -33,10 +33,10 @@ class TokenApiGateway:
             'size': 1,
             'request_timeout': int(ELASTIC_SEARCH_TIMEOUT),
             'query': {
-                'id': token_id,
+                'match': {
+                    'id': token_id,
+                }
             }
         }
 
-        response = self.elastic_search_client.run(body)
-
-        return elastic_search_utils.treat_response(response)
+        return elastic_search_utils.treat_response(self.elastic_search_client.run(body))

--- a/gateways/token_balances_api_gateway.py
+++ b/gateways/token_balances_api_gateway.py
@@ -39,7 +39,6 @@ class TokenBalancesApiGateway:
     def get_token_information(self, token_id: str) -> dict:
         """Retrieve total number of addresses and transactions for a given token_id
         """
-
         body = {
             'size': 0,
             'query': self._build_filtered_query(token_id),
@@ -51,18 +50,12 @@ class TokenBalancesApiGateway:
                         'field': 'address.keyword'
                     }
                 },
-                'transaction_sum': {
-                    'sum': {
-                        'field': 'transactions'
-                    }
-                }
             }
         }
 
         response = self.elastic_search_client.run(body)
 
         return {
-            'transactions': response['aggregations']['transaction_sum']['value'],
             'addresses': response['aggregations']['address_count']['value']
         }
 

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -58,7 +58,7 @@ def get_token(
     response = token_api.get_token(token_id)
 
     if len(response["hits"]) == 0:
-        raise ApiError("Token not found")
+        raise ApiError("not_found")
 
     return {
         "statusCode": 200,

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -57,7 +57,7 @@ def get_token(
 
     response = token_api.get_token(token_id)
 
-    if len(response['hits']) == 0:
+    if len(response["hits"]) == 0:
         raise ApiError("Token not found")
 
     return {

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -47,8 +47,9 @@ def get_token(
     _context: LambdaContext,
     token_api: TokenApi = TokenApi()
 ) -> dict:
-    """Get a specific token from its token_id"""
-
+    """Get a specific token from the elastic_search index
+       given an token_id
+    """
     token_id = event.path["token_id"]
 
     if token_id is None:

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -49,12 +49,15 @@ def get_token(
 ) -> dict:
     """Get a specific token from its token_id"""
 
-    token_id = event.query.get("token_id")
+    token_id = event.path["token_id"]
 
     if token_id is None:
         raise ApiError("Invalid token_id")
 
     response = token_api.get_token(token_id)
+
+    if len(response['hits']) == 0:
+        raise ApiError("Token not found")
 
     return {
         "statusCode": 200,

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -40,6 +40,7 @@ def get_tokens(
         }
     }
 
+
 @ApiGateway()
 def get_token(
     event: ApiGatewayEvent,
@@ -49,6 +50,9 @@ def get_token(
     """Get a specific token from its token_id"""
 
     token_id = event.query.get("token_id")
+
+    if token_id is None:
+        raise ApiError("Invalid token_id")
 
     response = token_api.get_token(token_id)
 

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -62,7 +62,7 @@ def get_token(
 
     return {
         "statusCode": 200,
-        "body": json.dumps(response or {}),
+        "body": json.dumps(response),
         "headers": {
             "Content-Type": "application/json"
         }

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -39,3 +39,23 @@ def get_tokens(
             "Content-Type": "application/json"
         }
     }
+
+@ApiGateway()
+def get_token(
+    event: ApiGatewayEvent,
+    _context: LambdaContext,
+    token_api: TokenApi = TokenApi()
+) -> dict:
+    """Get a specific token from its token_id"""
+
+    token_id = event.query.get("token_id")
+
+    response = token_api.get_tokens(search_text, sort_by, order, search_after_list)
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(response or {}),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }

--- a/handlers/token_api.py
+++ b/handlers/token_api.py
@@ -50,7 +50,7 @@ def get_token(
 
     token_id = event.query.get("token_id")
 
-    response = token_api.get_tokens(search_text, sort_by, order, search_after_list)
+    response = token_api.get_token(token_id)
 
     return {
         "statusCode": 200,

--- a/serverless.yml
+++ b/serverless.yml
@@ -268,6 +268,31 @@ functions:
               - name: request.querystring.search_after
               - name: request.header.origin
 
+  # This get_token will get tokens from the elasticsearch index
+  es_get_token_handler:
+    handler: handlers/token_api.get_token
+    timeout: 15
+    maximumRetryAttempts: 0
+    package:
+      patterns:
+        - 'handlers/token_api.py'
+    layers:
+      - { Ref: PythonRequirementsLambdaLayer }
+    events:
+      - http:
+          path: tokens/{token_id}
+          method: get
+          cors: true
+          caching:
+            enabled: true
+            ttlInSeconds: 300
+            cacheKeyParameters:
+              - name: request.querystring.search_text
+              - name: request.querystring.sort_by
+              - name: request.querystring.order
+              - name: request.querystring.search_after
+              - name: request.header.origin
+
   get_best_chain_height:
     handler: handlers/block_api.get_best_chain_height
     timeout: 30

--- a/serverless.yml
+++ b/serverless.yml
@@ -288,6 +288,7 @@ functions:
             ttlInSeconds: 300
             cacheKeyParameters:
               - name: request.header.origin
+              - name: request.path.token_id
 
   get_best_chain_height:
     handler: handlers/block_api.get_best_chain_height

--- a/serverless.yml
+++ b/serverless.yml
@@ -287,10 +287,6 @@ functions:
             enabled: true
             ttlInSeconds: 300
             cacheKeyParameters:
-              - name: request.querystring.search_text
-              - name: request.querystring.sort_by
-              - name: request.querystring.order
-              - name: request.querystring.search_after
               - name: request.header.origin
 
   get_best_chain_height:

--- a/tests/unit/gateways/clients/test_elastic_search_client.py
+++ b/tests/unit/gateways/clients/test_elastic_search_client.py
@@ -43,6 +43,7 @@ class TestElasticSearchClient:
                                 'name': 'Test1',
                                 'created_at': '2022-04-19T12:41:04Z',
                                 'transaction_timestamp': 1649473276,
+                                'transactions': 0,
                                 'id': '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a'
                             },
                             'sort': [
@@ -61,6 +62,7 @@ class TestElasticSearchClient:
                                 'name': 'Test2',
                                 'created_at': '2022-04-19T12:41:07Z',
                                 'transaction_timestamp': 1000000000,
+                                'transactions': 0,
                                 'id': '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a'
                             },
                             'sort': [
@@ -81,6 +83,7 @@ class TestElasticSearchClient:
                     'name': 'Test1',
                     'symbol': 'TST1',
                     'transaction_timestamp': 1649473276,
+                    'transactions_count': 0,
                     'sort': [
                         '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                         1649473276
@@ -92,6 +95,7 @@ class TestElasticSearchClient:
                     'name': 'Test2',
                     'symbol': 'TST2',
                     'transaction_timestamp': 1000000000,
+                    'transactions_count': 0,
                     'sort': [
                         '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                         1000000000

--- a/tests/unit/gateways/test_token_api_gateway.py
+++ b/tests/unit/gateways/test_token_api_gateway.py
@@ -38,6 +38,7 @@ class TestTokenApiGateway:
                                 'symbol': 'TST1',
                                 '@timestamp': '2022-04-19T13:56:04.371602Z',
                                 'name': 'Test1',
+                                'transactions': 0,
                                 'created_at': '2022-04-19T12:41:04Z',
                                 'transaction_timestamp': 1649473276,
                                 'id': '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a'
@@ -56,6 +57,7 @@ class TestTokenApiGateway:
                                 'symbol': 'TST2',
                                 '@timestamp': '2022-04-19T13:56:04.372449Z',
                                 'name': 'Test2',
+                                'transactions': 0,
                                 'created_at': '2022-04-19T12:41:07Z',
                                 'transaction_timestamp': 1000000000,
                                 'id': '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a'
@@ -79,6 +81,7 @@ class TestTokenApiGateway:
                     'id': '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                     'name': 'Test1',
                     'symbol': 'TST1',
+                    'transactions': 0,
                     'transaction_timestamp': 1649473276,
                     'sort': [
                         '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
@@ -90,6 +93,7 @@ class TestTokenApiGateway:
                     'id': '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                     'name': 'Test2',
                     'symbol': 'TST2',
+                    'transactions': 0,
                     'transaction_timestamp': 1000000000,
                     'sort': [
                         '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',

--- a/tests/unit/gateways/test_token_api_gateway.py
+++ b/tests/unit/gateways/test_token_api_gateway.py
@@ -81,24 +81,26 @@ class TestTokenApiGateway:
                     'id': '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                     'name': 'Test1',
                     'symbol': 'TST1',
-                    'transactions': 0,
                     'transaction_timestamp': 1649473276,
+                    'transactions_count': 0,
                     'sort': [
                         '00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                         1649473276
                     ],
+                    'transactions_count': 0,
                     'nft': False
                 },
                 {
                     'id': '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                     'name': 'Test2',
                     'symbol': 'TST2',
-                    'transactions': 0,
                     'transaction_timestamp': 1000000000,
+                    'transactions_count': 0,
                     'sort': [
                         '10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a',
                         1000000000
                     ],
+                    'transactions_count': 0,
                     'nft': False
                 }
             ],

--- a/tests/unit/gateways/test_token_api_gateway.py
+++ b/tests/unit/gateways/test_token_api_gateway.py
@@ -110,3 +110,91 @@ class TestTokenApiGateway:
         elastic_search_client.search.assert_called_once()
 
         assert result == expected_result
+
+    def test_get_token(self, elastic_search_client):
+        elastic_search_client.search = MagicMock(
+            return_value={
+                "took": 70,
+                "timed_out": False,
+                "_shards": {
+                    "total": 1,
+                    "successful": 1,
+                    "skipped": 0,
+                    "failed": 0
+                },
+                "hits": {
+                    "total": {
+                        "value": 1,
+                        "relation": "eq"
+                    },
+                    "max_score": 4.592441,
+                    "hits": [
+                        {
+                            "_index": "token-index",
+                            "_id": "00",
+                            "_score": 4.592441,
+                            "_source": {
+                                "transaction_timestamp": None,
+                                "transactions": 2061288,
+                                "name": "Hathor",
+                                "created_at": "2022-08-19T15:38:55Z",
+                                "id": "00",
+                                "@timestamp": "2022-08-24T13:42:10.124937Z",
+                                "symbol": "HTR",
+                                "updated_at": "2022-08-24T13:42:00Z"
+                            }
+                        }
+                    ]
+                }
+            }
+        )
+
+        gateway = TokenApiGateway(elastic_search_client=elastic_search_client)
+        result = gateway.get_token("00")
+
+        expected_result = {
+            "hits": [
+                {
+                    "id": "00",
+                    "name": "Hathor",
+                    "symbol": "HTR",
+                    "transaction_timestamp": None,
+                    "transactions_count": 2061288,
+                    "nft": False
+                }
+            ],
+            "has_next": False,
+        }
+
+        elastic_search_client.search.assert_called_once()
+        assert result == expected_result
+
+        elastic_search_client.search = MagicMock(
+            return_value={
+                "took": 70,
+                "timed_out": False,
+                "_shards": {
+                    "total": 1,
+                    "successful": 1,
+                    "skipped": 0,
+                    "failed": 0
+                },
+                "hits": {
+                    "total": {
+                        "value": 0,
+                        "relation": "eq"
+                    },
+                    "max_score": None,
+                    "hits": []
+                }
+            }
+        )
+
+        expected_result = {
+            "hits": [],
+            "has_next": False,
+        }
+
+        result_not_found = gateway.get_token("missing_token")
+
+        assert result_not_found == expected_result

--- a/tests/unit/gateways/test_token_balances_api_gateway.py
+++ b/tests/unit/gateways/test_token_balances_api_gateway.py
@@ -31,9 +31,6 @@ class TestTokenBalancesApiGateway:
                     'hits': []
                 },
                 'aggregations': {
-                    'transaction_sum': {
-                        'value': 478227.0
-                    },
                     'address_count': {
                         'value': 10868
                     }
@@ -46,7 +43,6 @@ class TestTokenBalancesApiGateway:
 
         expected_result = {
             'addresses': 10868,
-            'transactions': 478227,
         }
 
         elastic_search_client.search.assert_called_once()

--- a/tests/unit/usecases/test_token_api.py
+++ b/tests/unit/usecases/test_token_api.py
@@ -48,3 +48,31 @@ class TestTokenApi:
         token_api_gateway.get_tokens.assert_called_once_with("New", "", "", [])
         assert result
         assert sorted(result) == sorted(obj)
+
+    def test_get_token(self, token_api_gateway):
+        obj = {
+            "hits": [
+                {
+                    "id": "00",
+                    "name": "Hathor",
+                    "symbol": "HTR",
+                    "transaction_timestamp": 1649473276,
+                    "sort": [
+                        "00",
+                        1649473276
+                    ],
+                    "nft": False
+                }
+            ],
+            "has_next": False
+        }
+
+        token_api_gateway.get_tokens = MagicMock(return_value=obj)
+
+        token_api = TokenApi(token_api_gateway)
+
+        result = token_api.get_token("00")
+        token_api_gateway.get_token.assert_called_once_with("00")
+
+        assert result
+        assert sorted(result) == sorted(obj)

--- a/tests/unit/usecases/test_token_api.py
+++ b/tests/unit/usecases/test_token_api.py
@@ -19,6 +19,7 @@ class TestTokenApi:
                     "name": "Test1",
                     "symbol": "TST1",
                     "transaction_timestamp": 1649473276,
+                    "transactions": 0,
                     "sort": [
                         "00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1649473276
@@ -30,6 +31,7 @@ class TestTokenApi:
                     "name": "Test2",
                     "symbol": "TST2",
                     "transaction_timestamp": 1000000000,
+                    "transactions": 0,
                     "sort": [
                         "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1000000000
@@ -57,6 +59,7 @@ class TestTokenApi:
                     "name": "Hathor",
                     "symbol": "HTR",
                     "transaction_timestamp": 1649473276,
+                    "transactions": 0,
                     "sort": [
                         "00",
                         1649473276

--- a/tests/unit/usecases/test_token_api.py
+++ b/tests/unit/usecases/test_token_api.py
@@ -19,7 +19,7 @@ class TestTokenApi:
                     "name": "Test1",
                     "symbol": "TST1",
                     "transaction_timestamp": 1649473276,
-                    "transactions": 0,
+                    "transactions": 3,
                     "sort": [
                         "00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1649473276
@@ -31,7 +31,7 @@ class TestTokenApi:
                     "name": "Test2",
                     "symbol": "TST2",
                     "transaction_timestamp": 1000000000,
-                    "transactions": 0,
+                    "transactions": 3,
                     "sort": [
                         "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1000000000
@@ -59,7 +59,7 @@ class TestTokenApi:
                     "name": "Hathor",
                     "symbol": "HTR",
                     "transaction_timestamp": 1649473276,
-                    "transactions": 0,
+                    "transactions_count": 3,
                     "sort": [
                         "00",
                         1649473276
@@ -67,15 +67,15 @@ class TestTokenApi:
                     "nft": False
                 }
             ],
-            "has_next": False
         }
 
-        token_api_gateway.get_tokens = MagicMock(return_value=obj)
+        token_api_gateway.get_token = MagicMock(return_value=obj)
 
         token_api = TokenApi(token_api_gateway)
 
-        result = token_api.get_token("00")
-        token_api_gateway.get_token.assert_called_once_with("00")
-
+        result = token_api.get_token(
+                "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a")
+        token_api_gateway.get_token.assert_called_once_with(
+                "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a")
         assert result
         assert sorted(result) == sorted(obj)

--- a/tests/unit/utils/elastic_search/test_elastic_search_utils.py
+++ b/tests/unit/utils/elastic_search/test_elastic_search_utils.py
@@ -84,6 +84,7 @@ class TestElasticSearchUtils:
                             "name": "Test1",
                             "created_at": "2022-04-19T12:41:04Z",
                             "transaction_timestamp": 1649473276,
+                            "transactions": 3,
                             "id": "00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a"
                         },
                         "sort": [
@@ -102,6 +103,7 @@ class TestElasticSearchUtils:
                             "name": "Test2",
                             "created_at": "2022-04-19T12:41:07Z",
                             "transaction_timestamp": 1000000000,
+                            "transactions": 3,
                             "id": "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a"
                         },
                         "sort": [
@@ -123,6 +125,7 @@ class TestElasticSearchUtils:
                         "00000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1649473276
                     ],
+                    "transactions_count": 3,
                     "nft": False
                 },
                 {
@@ -134,6 +137,7 @@ class TestElasticSearchUtils:
                         "10000000906db3a2146ec96b452f9ff7431fa273a432d9b14837eb72e17b587a",
                         1000000000
                     ],
+                    "transactions_count": 3,
                     "nft": False
                 }
             ],
@@ -141,4 +145,6 @@ class TestElasticSearchUtils:
         }
 
         result = utils.treat_response(es_response)
+        print(result)
+        print(expected_treated_response)
         assert result == expected_treated_response

--- a/tests/unit/utils/elastic_search/test_elastic_search_utils.py
+++ b/tests/unit/utils/elastic_search/test_elastic_search_utils.py
@@ -25,7 +25,6 @@ class TestElasticSearchUtils:
         search_after = []
 
         result = utils.build_search_query(search_text, sort_by, order, search_after)
-        print(result)
         assert result['query'] is not None
         assert result['query']['multi_match'] is not None
         assert result['query']['multi_match']['query'] == search_text
@@ -145,6 +144,4 @@ class TestElasticSearchUtils:
         }
 
         result = utils.treat_response(es_response)
-        print(result)
-        print(expected_treated_response)
         assert result == expected_treated_response

--- a/usecases/token_api.py
+++ b/usecases/token_api.py
@@ -11,4 +11,4 @@ class TokenApi:
         return self.token_api_gateway.get_tokens(search_text, sort_by, order, search_after)
 
     def get_token(self, token_id: str) -> dict:
-        return self.token_api_gateway.get_tokens(token_id)
+        return self.token_api_gateway.get_token(token_id)

--- a/usecases/token_api.py
+++ b/usecases/token_api.py
@@ -9,3 +9,6 @@ class TokenApi:
 
     def get_tokens(self, search_text: str, sort_by: str, order: str, search_after: List[str]) -> dict:
         return self.token_api_gateway.get_tokens(search_text, sort_by, order, search_after)
+
+    def get_token(self, token_id: str) -> dict:
+        return self.token_api_gateway.get_tokens(token_id)

--- a/utils/elastic_search/elastic_search_utils.py
+++ b/utils/elastic_search/elastic_search_utils.py
@@ -19,7 +19,7 @@ SORTABLE_FIELDS_BY_INDEX = {
         'id': 'keyword',
         'name': 'keyword',
         'symbol': 'keyword',
-        'transactions': 'integer',
+        'transactions_count': 'integer',
     },
     ELASTIC_TOKEN_BALANCES_INDEX: {
         'address': 'keyword',

--- a/utils/elastic_search/elastic_search_utils.py
+++ b/utils/elastic_search/elastic_search_utils.py
@@ -19,6 +19,7 @@ SORTABLE_FIELDS_BY_INDEX = {
         'id': 'keyword',
         'name': 'keyword',
         'symbol': 'keyword',
+        'transactions': 'integer',
     },
     ELASTIC_TOKEN_BALANCES_INDEX: {
         'address': 'keyword',

--- a/utils/elastic_search/transformations/token_api.py
+++ b/utils/elastic_search/transformations/token_api.py
@@ -9,7 +9,8 @@ def es_hit_to_result(hit: dict) -> dict:
         'name': hit['_source']['name'],
         'symbol': hit['_source']['symbol'],
         'transaction_timestamp': hit['_source']['transaction_timestamp'],
-        'sort': hit['sort']
+        'sort': hit['sort'],
+        'transactions': hit['transactions'],
     }
 
     if 'nft' in hit['_source']:

--- a/utils/elastic_search/transformations/token_api.py
+++ b/utils/elastic_search/transformations/token_api.py
@@ -9,8 +9,8 @@ def es_hit_to_result(hit: dict) -> dict:
         'name': hit['_source']['name'],
         'symbol': hit['_source']['symbol'],
         'transaction_timestamp': hit['_source']['transaction_timestamp'],
+        'transactions_count': hit['_source']['transactions'],
         'sort': hit['sort'],
-        'transactions': hit['transactions'],
     }
 
     if 'nft' in hit['_source']:

--- a/utils/elastic_search/transformations/token_api.py
+++ b/utils/elastic_search/transformations/token_api.py
@@ -10,8 +10,11 @@ def es_hit_to_result(hit: dict) -> dict:
         'symbol': hit['_source']['symbol'],
         'transaction_timestamp': hit['_source']['transaction_timestamp'],
         'transactions_count': hit['_source']['transactions'],
-        'sort': hit['sort'],
     }
+
+    # If we are searching for a single result, we won't have sort in the result
+    if 'sort' in hit:
+        result['sort'] = hit['sort']
 
     if 'nft' in hit['_source']:
         result['nft'] = hit['_source']['nft']


### PR DESCRIPTION
### Acceptance Criteria
- We should have an API to retrieve a specific token by its token_id
- We should add the `transactions_count` attribute to the token response
- We should remove the `transactions` aggregation from the token information API

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
