### PR TITLE
fix: count tokens query

### DIFF
--- a/gateways/clients/wallet_service_db_client.py
+++ b/gateways/clients/wallet_service_db_client.py
@@ -116,7 +116,8 @@ class WalletServiceDBClient:
         ''' Fetch the tokens an address has any history with.
 
         HTR will always be the first token if HTR is on the token history.
-        This is done by querying for HTR first if we are on the first page (`offset` == 0) then querying for other tokens.
+        This is done by querying for HTR first if we are on the first page (`offset` == 0)
+        then querying for other tokens.
 
         The total number of tokens on the address history is also returned.
         '''

--- a/gateways/clients/wallet_service_db_client.py
+++ b/gateways/clients/wallet_service_db_client.py
@@ -46,7 +46,7 @@ LIMIT :limit OFFSET :offset'''
 address_tokens_query: str = '''\
 SELECT address_balance.token_id AS token_id,
        token.name AS name,
-       token.symbol AS symbol,
+       token.symbol AS symbol
 FROM token INNER JOIN address_balance ON token.id = address_balance.token_id
 WHERE address_balance.address = :address AND token.id != '00'
 ORDER BY address_balance.updated_at DESC

--- a/gateways/wallet_service_gateway.py
+++ b/gateways/wallet_service_gateway.py
@@ -23,7 +23,6 @@ class WalletServiceGateway:
 
         Returns the total number of different tokens and a list of tokens found.
         """
-        tokens = self.db_client.get_address_tokens(address, limit, offset)
-        total: int = tokens[0]['total'] if len(tokens) > 0 else 0
+        total, tokens = self.db_client.get_address_tokens(address, limit, offset)
 
         return total, [TokenEntry.from_dict(token) for token in tokens]

--- a/tests/unit/gateways/test_wallet_service.py
+++ b/tests/unit/gateways/test_wallet_service.py
@@ -31,11 +31,7 @@ class TestWalletServiceDBClient:
         limit = fake.pyint()
         offset = fake.pyint()
 
-        # we only check the first entry for the `total` value since all should contain the same `total`
-        t1dict = token1.to_dict()
-        t1dict['total'] = total
-
-        db_client.get_address_tokens.return_value = [t1dict, token2.to_dict(), htr_token_dict]
+        db_client.get_address_tokens.return_value = (total, [htr_token_dict, token1.to_dict(), token2.to_dict()])
 
         gw = WalletServiceGateway(db_client)
 
@@ -43,7 +39,7 @@ class TestWalletServiceDBClient:
 
         assert total_returned == total
         assert len(returned) == 3
-        assert all([ret == exp for ret, exp in zip(returned, [token1, token2, htr_token])])
+        assert all([ret == exp for ret, exp in zip(returned, [htr_token, token1, token2])])
 
         assert db_client.get_address_tokens.called_once_with(address, limit, offset)
 


### PR DESCRIPTION
### Acceptance Criteria
Since HTR is searched before any token, both queries we make will not contain all tokens so we should query for the total number of tokens separately.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
