### PR TITLE
fix: adding index to the token api query

### DIFF
--- a/gateways/token_api_gateway.py
+++ b/gateways/token_api_gateway.py
@@ -32,6 +32,7 @@ class TokenApiGateway:
         body = {
             'size': 1,
             'request_timeout': int(ELASTIC_SEARCH_TIMEOUT),
+            'index': ELASTIC_INDEX,
             'query': {
                 'match': {
                     'id': token_id,


### PR DESCRIPTION
### Acceptance Criteria
- The token API should query only the correct index, and not all of them


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
