### PR TITLE
chore: fixed cache key params on handle address history

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -640,7 +640,8 @@ functions:
               - name: request.querystring.address
               - name: request.querystring.token
               - name: request.querystring.limit
-              - name: request.querystring.offset
+              - name: request.querystring.last_tx
+              - name: request.querystring.last_ts
               - name: request.header.origin
 
   walletServiceAddressTokens:


### PR DESCRIPTION
### Acceptance Criteria
- We should update the cache parameters for the address history API so it will cache properly


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
