### PR TITLE
fix: do not use poetry after install --no-dev

### DIFF
--- a/Dockerfile_Daemons
+++ b/Dockerfile_Daemons
@@ -17,4 +17,4 @@ RUN poetry config virtualenvs.create false \
 # copy the content of the local src directory to the working directory
 COPY . .
 # command to run on container start
-CMD [ "poetry", "run", "python", "-u", "./daemons_runner.py" ]
+CMD [ "python", "-u", "./daemons_runner.py" ]


### PR DESCRIPTION
### Description

`poetry install --no-dev` now removes its own dependencies since `--no-dev` implies a production environment.
This broke the `Dockerfile_Daemons` since the container command runs `poetry run python ...` and a missing dependency error is raised (this [alert](https://hathor.app.opsgenie.com/alert/detail/62773674-a3f5-4d59-b345-ab3cfe4e3aef-1666039181373/details))

To fix this we run the command from python instead of poetry.

### Acceptance Criteria

- Do not use poetry commands on production after `poetry install --no-dev`.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
