### PR TITLE
fix: the PR checks were not running for recently opened PRs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,7 +1,6 @@
 name: PR Validation
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
   push:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,7 +1,7 @@
 name: PR Validation
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [opened, synchronize, reopened]
     paths-ignore:
       - '**.md'
   push:

--- a/daemons/data_collector.py
+++ b/daemons/data_collector.py
@@ -2,10 +2,11 @@
 
 import asyncio
 
-from usecases.collect_nodes_statuses import CollectNodesStatuses
 from common.logging import get_logger
+from usecases.collect_nodes_statuses import CollectNodesStatuses
 
 logger = get_logger()
+
 
 class DataCollector:
     async def run(self) -> None:

--- a/gateways/node_gateway.py
+++ b/gateways/node_gateway.py
@@ -15,6 +15,7 @@ from gateways.clients.lambda_client import LambdaClient
 
 logger = get_logger()
 
+
 class NodeGateway:
     """Gateway for Node actions
 


### PR DESCRIPTION
### Acceptance Criteria
- The PR checks in Github Actions should run for PRs that were just opened. They weren't before.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
