### PR TITLE
fix: python3.8 not found during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, dev, fix/deploy]
+    branches: [main, dev]
     tags: ['v*.*.*']
 
 env:
@@ -41,9 +41,6 @@ jobs:
             echo "Setting testnet environment"
             echo "::set-output name=environment::testnet"
           elif [[ "${{github.base_ref}}" == "dev" || "${{github.ref}}" == "refs/heads/dev" ]]; then
-            echo "Setting dev environment"
-            echo "::set-output name=environment::dev"
-          else
             echo "Setting dev environment"
             echo "::set-output name=environment::dev"
           fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main, dev, fix/deploy]
     tags: ['v*.*.*']
 
 env:
@@ -41,6 +41,9 @@ jobs:
             echo "Setting testnet environment"
             echo "::set-output name=environment::testnet"
           elif [[ "${{github.base_ref}}" == "dev" || "${{github.ref}}" == "refs/heads/dev" ]]; then
+            echo "Setting dev environment"
+            echo "::set-output name=environment::dev"
+          else
             echo "Setting dev environment"
             echo "::set-output name=environment::dev"
           fi

--- a/serverless.yml
+++ b/serverless.yml
@@ -72,6 +72,7 @@ custom:
     host: 0.0.0.0
   pythonRequirements:
     layer: true
+    pythonBin: python3
   s3:
     host: localhost
     directory: /tmp


### PR DESCRIPTION
### Acceptance Criteria

- The deploy pipeline should run successfully

### Explanation

We started to have problems with `serverless-python-requirements` plugin when deploying the Lambdas: https://github.com/HathorNetwork/hathor-explorer-service/actions/runs/3542218948/jobs/5947524789

The error was `python3.8 not found`.

Setting the python to be used by the plugin to any python3 available solves the issue (reference: https://stackoverflow.com/questions/57740310/serverless-python3-7-not-found-try-the-pythonbin-option)

The new run is working again: https://github.com/HathorNetwork/hathor-explorer-service/actions/runs/3542880636/jobs/5948842767

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
