### PR TITLE
chore: set timeout for node api calls

### DIFF
--- a/gateways/node_api_gateway.py
+++ b/gateways/node_api_gateway.py
@@ -16,7 +16,9 @@ from gateways.clients.hathor_core_client import (
     HathorCoreClient,
 )
 
-# The default lambda timeout for Node API Lambdas is set to 6 seconds.
+# The default lambda timeout for Node API Lambdas is set to
+# 6 seconds. Therefore, the client should have a lower timeout,
+# to let the lambda shut down gracefully.
 NODE_API_TIMEOUT_IN_SECONDS = 5
 
 
@@ -59,7 +61,9 @@ class NodeApiGateway:
         return self.hathor_core_client.get(
             ADDRESS_BALANCE_ENDPOINT,
             params={"address": address},
-            timeout=14,  # lambda timeout 15s
+            # lambda timeout 15s, which is the sum of all lambda's steps timeout
+            # see: https://github.com/HathorNetwork/hathor-explorer-service/pull/93
+            timeout=10,
         )
 
     def get_address_search(
@@ -89,7 +93,9 @@ class NodeApiGateway:
         return self.hathor_core_client.get(
             ADDRESS_SEARCH_ENDPOINT,
             params=params,
-            timeout=14,  # lambda timeout 15s
+            # lambda timeout 15s, which is the sum of all lambda's steps timeout
+            # see: https://github.com/HathorNetwork/hathor-explorer-service/pull/93
+            timeout=10,  # lambda timeout 15s
         )
 
     def get_version(self) -> Optional[dict]:

--- a/gateways/node_api_gateway.py
+++ b/gateways/node_api_gateway.py
@@ -16,6 +16,9 @@ from gateways.clients.hathor_core_client import (
     HathorCoreClient,
 )
 
+# The default lambda timeout for Node API Lambdas is set to 6 seconds.
+NODE_API_TIMEOUT_IN_SECONDS = 5
+
 
 class NodeApiGateway:
     """Gateway to interact with the full-node api"""
@@ -56,7 +59,7 @@ class NodeApiGateway:
         return self.hathor_core_client.get(
             ADDRESS_BALANCE_ENDPOINT,
             params={"address": address},
-            timeout=10,
+            timeout=14,  # lambda timeout 15s
         )
 
     def get_address_search(
@@ -86,25 +89,33 @@ class NodeApiGateway:
         return self.hathor_core_client.get(
             ADDRESS_SEARCH_ENDPOINT,
             params=params,
-            timeout=10,
+            timeout=14,  # lambda timeout 15s
         )
 
     def get_version(self) -> Optional[dict]:
         """Retrieve version information"""
 
-        return self.hathor_core_client.get(VERSION_ENDPOINT)
+        return self.hathor_core_client.get(
+            VERSION_ENDPOINT, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
 
     def get_dashboard_tx(self, block: int, tx: int) -> Optional[dict]:
         """Retrieve info on blocks and transaction to show on dashboard"""
 
         return self.hathor_core_client.get(
-            DASHBOARD_TX_ENDPOINT, params={"tx": tx, "block": block}
+            DASHBOARD_TX_ENDPOINT,
+            params={"tx": tx, "block": block},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
 
     def get_transaction_acc_weight(self, id: str) -> Optional[dict]:
         """Retrieve acc weight for a tx"""
 
-        return self.hathor_core_client.get(TX_ACC_WEIGHT_ENDPOINT, params={"id": id})
+        return self.hathor_core_client.get(
+            TX_ACC_WEIGHT_ENDPOINT,
+            params={"id": id},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
+        )
 
     def get_token_history(
         self,
@@ -122,21 +133,31 @@ class NodeApiGateway:
             params["page"] = page
             params["timestamp"] = timestamp
 
-        return self.hathor_core_client.get(TOKEN_HISTORY_ENDPOINT, params=params)
+        return self.hathor_core_client.get(
+            TOKEN_HISTORY_ENDPOINT, params=params, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
 
     def get_transaction(self, id: str) -> Optional[dict]:
         """Retrieve transaction by id"""
-        return self.hathor_core_client.get(TRANSACTION_ENDPOINT, params={"id": id})
+        return self.hathor_core_client.get(
+            TRANSACTION_ENDPOINT, params={"id": id}, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
 
     def decode_tx(self, hex_tx: str) -> Optional[dict]:
         """Decode a transaction from it's hex encoded struct data."""
         return self.hathor_core_client.get(
-            DECODE_TX_ENDPOINT, params={"hex_tx": hex_tx}
+            DECODE_TX_ENDPOINT,
+            params={"hex_tx": hex_tx},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
 
     def push_tx(self, hex_tx: str) -> Optional[dict]:
         """Push a transaction from it's hex encoded struct data."""
-        return self.hathor_core_client.get(PUSH_TX_ENDPOINT, params={"hex_tx": hex_tx})
+        return self.hathor_core_client.get(
+            PUSH_TX_ENDPOINT,
+            params={"hex_tx": hex_tx},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
+        )
 
     def graphviz_dot_neighbors(
         self, tx: str, graph_type: str, max_level: int
@@ -148,7 +169,9 @@ class NodeApiGateway:
             "max_level": max_level,
         }
         return self.hathor_core_client.get_text(
-            GRAPHVIZ_DOT_NEIGHBORS_ENDPOINT, params=data
+            GRAPHVIZ_DOT_NEIGHBORS_ENDPOINT,
+            params=data,
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
 
     def list_transactions(
@@ -167,8 +190,12 @@ class NodeApiGateway:
             params["page"] = page
             params["timestamp"] = timestamp
 
-        return self.hathor_core_client.get(TRANSACTION_ENDPOINT, params=params)
+        return self.hathor_core_client.get(
+            TRANSACTION_ENDPOINT, params=params, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
 
     def get_token(self, id: str) -> Optional[dict]:
         """Retrieve token by id"""
-        return self.hathor_core_client.get(TOKEN_ENDPOINT, params={"id": id})
+        return self.hathor_core_client.get(
+            TOKEN_ENDPOINT, params={"id": id}, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )

--- a/serverless.yml
+++ b/serverless.yml
@@ -390,6 +390,7 @@ functions:
 
   node_api_get_version:
     handler: handlers/node_api.get_version
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -409,6 +410,7 @@ functions:
 
   node_api_get_dashboard_tx:
     handler: handlers/node_api.get_dashboard_tx
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -430,6 +432,7 @@ functions:
 
   node_api_get_tx_acc_w:
     handler: handlers/node_api.get_transaction_acc_weight
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -450,6 +453,7 @@ functions:
 
   node_api_get_token_history:
     handler: handlers/node_api.get_token_history
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -474,6 +478,7 @@ functions:
 
   node_api_get_transaction:
     handler: handlers/node_api.get_transaction
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -494,6 +499,7 @@ functions:
 
   node_api_list_transactions:
     handler: handlers/node_api.list_transactions
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -518,6 +524,7 @@ functions:
 
   node_api_get_token:
     handler: handlers/node_api.get_token
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -538,6 +545,7 @@ functions:
 
   node_api_decode_tx:
     handler: handlers/node_api.decode_tx
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -558,6 +566,7 @@ functions:
 
   node_api_push_tx:
     handler: handlers/node_api.push_tx
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:
@@ -578,6 +587,7 @@ functions:
 
   node_api_gviz_dot_neighbors:
     handler: handlers/node_api.graphviz_dot_neighbors
+    timeout: 6
     maximumRetryAttempts: 0
     package:
       patterns:

--- a/tests/unit/gateways/test_node_api_gateway.py
+++ b/tests/unit/gateways/test_node_api_gateway.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 
 from pytest import fixture
 
-from gateways.node_api_gateway import NodeApiGateway
+from gateways.node_api_gateway import NODE_API_TIMEOUT_IN_SECONDS, NodeApiGateway
 from tests.fixtures.node_api_factory import (
     AddressBalanceFactory,
     AddressSearchFactory,
@@ -47,7 +47,7 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_address_balance("mock-address")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"address": "mock-address"}, timeout=10
+            "mock-endpoint", params={"address": "mock-address"}, timeout=14
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -66,7 +66,7 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_address_search("mock-address", 1)
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"address": "mock-address", "count": 1}, timeout=10
+            "mock-endpoint", params={"address": "mock-address", "count": 1}, timeout=14
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -75,7 +75,7 @@ class TestNodeApiGateway:
         hathor_client.get.assert_called_with(
             "mock-endpoint",
             params={"address": "mock-address", "count": 5, "token": "mock-token"},
-            timeout=10,
+            timeout=14,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -91,7 +91,7 @@ class TestNodeApiGateway:
                 "hash": "a-hash",
                 "page": "next",
             },
-            timeout=10,
+            timeout=14,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -109,7 +109,9 @@ class TestNodeApiGateway:
         hathor_client.get = MagicMock(return_value=obj)
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_version()
-        hathor_client.get.assert_called_once_with("mock-endpoint")
+        hathor_client.get.assert_called_once_with(
+            "mock-endpoint", timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
         assert result
         assert sorted(result) == sorted(obj)
 
@@ -120,7 +122,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_dashboard_tx(15, 5)
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"tx": 5, "block": 15}
+            "mock-endpoint",
+            params={"tx": 5, "block": 15},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -132,7 +136,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_transaction_acc_weight("mock-txid")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"id": "mock-txid"}
+            "mock-endpoint",
+            params={"id": "mock-txid"},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -144,7 +150,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_token_history("mock-id-1", 1)
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"id": "mock-id-1", "count": 1}
+            "mock-endpoint",
+            params={"id": "mock-id-1", "count": 1},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -159,6 +167,7 @@ class TestNodeApiGateway:
                 "page": None,
                 "timestamp": None,
             },
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -173,6 +182,7 @@ class TestNodeApiGateway:
                 "page": "next",
                 "timestamp": 123,
             },
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -184,7 +194,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_transaction("mock-txid")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"id": "mock-txid"}
+            "mock-endpoint",
+            params={"id": "mock-txid"},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -196,7 +208,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.list_transactions("type-1", 1)
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"type": "type-1", "count": 1}
+            "mock-endpoint",
+            params={"type": "type-1", "count": 1},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -211,6 +225,7 @@ class TestNodeApiGateway:
                 "page": None,
                 "timestamp": None,
             },
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -225,6 +240,7 @@ class TestNodeApiGateway:
                 "page": "next",
                 "timestamp": 123,
             },
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -236,7 +252,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_token("mock-token-uid")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"id": "mock-token-uid"}
+            "mock-endpoint",
+            params={"id": "mock-token-uid"},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -248,7 +266,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.decode_tx("hex-tx-data")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"hex_tx": "hex-tx-data"}
+            "mock-endpoint",
+            params={"hex_tx": "hex-tx-data"},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -260,7 +280,9 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.push_tx("hex-tx-data")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"hex_tx": "hex-tx-data"}
+            "mock-endpoint",
+            params={"hex_tx": "hex-tx-data"},
+            timeout=NODE_API_TIMEOUT_IN_SECONDS,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -276,6 +298,8 @@ class TestNodeApiGateway:
         hathor_client.get_text = MagicMock(return_value=obj)
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.graphviz_dot_neighbors(**data)
-        hathor_client.get_text.assert_called_once_with("mock-endpoint", params=data)
+        hathor_client.get_text.assert_called_once_with(
+            "mock-endpoint", params=data, timeout=NODE_API_TIMEOUT_IN_SECONDS
+        )
         assert result
         assert result == obj

--- a/tests/unit/gateways/test_node_api_gateway.py
+++ b/tests/unit/gateways/test_node_api_gateway.py
@@ -47,7 +47,7 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_address_balance("mock-address")
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"address": "mock-address"}, timeout=14
+            "mock-endpoint", params={"address": "mock-address"}, timeout=10
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -66,7 +66,7 @@ class TestNodeApiGateway:
         gateway = NodeApiGateway(hathor_core_client=hathor_client)
         result = gateway.get_address_search("mock-address", 1)
         hathor_client.get.assert_called_once_with(
-            "mock-endpoint", params={"address": "mock-address", "count": 1}, timeout=14
+            "mock-endpoint", params={"address": "mock-address", "count": 1}, timeout=10
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -75,7 +75,7 @@ class TestNodeApiGateway:
         hathor_client.get.assert_called_with(
             "mock-endpoint",
             params={"address": "mock-address", "count": 5, "token": "mock-token"},
-            timeout=14,
+            timeout=10,
         )
         assert result
         assert sorted(result) == sorted(obj)
@@ -91,7 +91,7 @@ class TestNodeApiGateway:
                 "hash": "a-hash",
                 "page": "next",
             },
-            timeout=14,
+            timeout=10,
         )
         assert result
         assert sorted(result) == sorted(obj)


### PR DESCRIPTION
### Acceptance Criteria
- turn explicit the timeout value for Node Api lambdas
- set timeout for Node Api client calls


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

Closes: https://github.com/HathorNetwork/hathor-explorer-service/issues/133