### PR TITLE
chore: update old github actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,17 +52,21 @@ jobs:
     environment: ${{ needs.init.outputs.environment }}
 
     steps:
-      - uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases/tag/v3.5.3
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Set up Python
-        uses: actions/setup-python@v2
+        # https://github.com/actions/setup-python/releases/tag/v4.7.0
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: 3.9
       - name: Set up Node.js 14.x
-        uses: actions/setup-node@v1
+        # https://github.com/actions/setup-node/releases/tag/v3.7.0
+        uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
         with:
           node-version: 14.x
       - name: Cache node modules
-        uses: actions/cache@v2
+        # https://github.com/actions/cache/releases/tag/v3.3.1
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,9 +14,11 @@ jobs:
         python-version: [3.9]
     steps:
       - name: Checkout to branch
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases/tag/v3.5.3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Set up Python
-        uses: actions/setup-python@v2
+        # https://github.com/actions/setup-python/releases/tag/v4.7.0
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies


### PR DESCRIPTION
### Acceptance Criteria
- Update github actions versions due to node12 deprecation ([reference](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/))


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
