### PR TITLE
feat: data collector health ping

### DIFF
--- a/common/configuration.py
+++ b/common/configuration.py
@@ -89,3 +89,9 @@ WALLET_SERVICE_DB_USERNAME = config("WALLET_SERVICE_DB_USERNAME", default=None)
 WALLET_SERVICE_DB_PASSWORD = config("WALLET_SERVICE_DB_PASSWORD", default=None)
 WALLET_SERVICE_DB_HOST = config("WALLET_SERVICE_DB_HOST", default=None)
 WALLET_SERVICE_DB_NAME = config("WALLET_SERVICE_DB_NAME", default=None)
+
+# This ping functionality will be used by the data collector daemon to send pings to a health monitor service
+HEALTHCHECK_PING_ENABLED = config("HEALTHCHECK_PING_ENABLED", default=False, cast=bool)
+HEALTHCHECK_PING_INTERVAL = config("HEALTHCHECK_PING_INTERVAL", default=30, cast=int)
+HEALTHCHECK_SERVICE_API_KEY = config("HEALTHCHECK_SERVICE_API_KEY", default="")
+HEALTHCHECK_DATA_COLLECTOR_URL = config("HEALTHCHECK_DATA_COLLECTOR_URL", default=None)

--- a/daemons/data_collector.py
+++ b/daemons/data_collector.py
@@ -1,16 +1,30 @@
 #!/usr/bin/env python3
 
 import asyncio
+from typing import Optional
 
+from common.configuration import HEALTHCHECK_PING_ENABLED
 from common.logging import get_logger
 from usecases.collect_nodes_statuses import CollectNodesStatuses
+from utils.healthcheck.healthcheck_ping_manager import HealthcheckPingManager
 
 logger = get_logger()
 
 
 class DataCollector:
+    def __init__(
+        self, healthcheck_ping_manager: Optional[HealthcheckPingManager] = None
+    ) -> None:
+        if not healthcheck_ping_manager and HEALTHCHECK_PING_ENABLED:
+            healthcheck_ping_manager = HealthcheckPingManager()
+
+        self.healthcheck_ping_manager = healthcheck_ping_manager
+
     async def run(self) -> None:
         await CollectNodesStatuses().collect()
+        if self.healthcheck_ping_manager:
+            # This sends a ping to the configured healthcheck service (if any)
+            await self.healthcheck_ping_manager.send_ping("data_collector")
 
 
 def main() -> None:

--- a/tests/unit/utils/healthcheck/test_healthcheck_ping_manager.py
+++ b/tests/unit/utils/healthcheck/test_healthcheck_ping_manager.py
@@ -1,0 +1,86 @@
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from utils.healthcheck.healthcheck_ping_manager import HealthcheckPingManager
+
+
+@patch(
+    "utils.healthcheck.healthcheck_ping_manager.HEALTHCHECK_PING_ENABLED",
+    True,
+)
+class TestHealthcheckPingManager(unittest.IsolatedAsyncioTestCase):
+    @patch("aiohttp.ClientSession.post")
+    async def test_send_post(self, mock_post):
+        ping_manager = HealthcheckPingManager()
+
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        await ping_manager._send_post("http://test.com")
+
+        mock_post.assert_called_once()
+
+    @patch("aiohttp.ClientSession.post")
+    async def test_send_post_server_error(self, mock_post):
+        ping_manager = HealthcheckPingManager()
+
+        mock_response = MagicMock()
+        mock_response.status = 500
+        mock_post.return_value.__aenter__.return_value = mock_response
+
+        # Shouldn't raise any exception
+        await ping_manager._send_post("http://test.com")
+
+        mock_post.assert_called_once()
+
+    @patch("aiohttp.ClientSession.post")
+    async def test_send_post_network_error(self, mock_post):
+        ping_manager = HealthcheckPingManager()
+
+        mock_post.side_effect = Exception("test")
+
+        # Shouldn't raise any exception
+        await ping_manager._send_post("http://test.com")
+
+        mock_post.assert_called_once()
+
+    @patch(
+        "utils.healthcheck.healthcheck_ping_manager.HEALTHCHECK_DATA_COLLECTOR_URL",
+        "http://test.com",
+    )
+    @patch(
+        "utils.healthcheck.healthcheck_ping_manager.HealthcheckPingManager._send_post"
+    )
+    async def test_send_ping(self, mock_send_post):
+        ping_manager = HealthcheckPingManager()
+        ping_manager.targets["data_collector"][
+            "latest_ping"
+        ] = datetime.now() - timedelta(minutes=10)
+
+        await ping_manager.send_ping("data_collector")
+
+        mock_send_post.assert_called_once_with("http://test.com")
+
+    @patch(
+        "utils.healthcheck.healthcheck_ping_manager.HealthcheckPingManager._send_post"
+    )
+    async def test_send_ping_disabled(self, mock_send_post):
+        with patch(
+            "utils.healthcheck.healthcheck_ping_manager.HEALTHCHECK_PING_ENABLED", False
+        ):
+            ping_manager = HealthcheckPingManager()
+            await ping_manager.send_ping("data_collector")
+
+            mock_send_post.assert_not_called()
+
+    async def test_send_ping_invalid_target(self):
+        ping_manager = HealthcheckPingManager()
+
+        with self.assertRaises(ValueError):
+            await ping_manager.send_ping("invalid_target")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/healthcheck/healthcheck_ping_manager.py
+++ b/utils/healthcheck/healthcheck_ping_manager.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+
+import aiohttp
+
+from common.configuration import (
+    HEALTHCHECK_DATA_COLLECTOR_URL,
+    HEALTHCHECK_PING_ENABLED,
+    HEALTHCHECK_PING_INTERVAL,
+    HEALTHCHECK_SERVICE_API_KEY,
+)
+from common.logging import get_logger
+
+logger = get_logger()
+
+
+class HealthcheckPingManager:
+    def __init__(self) -> None:
+        self.targets = {
+            "data_collector": {
+                "interval": HEALTHCHECK_PING_INTERVAL,
+                "url": HEALTHCHECK_DATA_COLLECTOR_URL,
+                "latest_ping": None,
+            }
+        }
+
+    async def _send_post(self, url: str) -> None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                headers = {
+                    "X-Api-Key": HEALTHCHECK_SERVICE_API_KEY,
+                    "Content-Type": "application/json",
+                }
+
+                async with session.post(url, headers=headers) as response:
+                    if response.status > 299:
+                        data = await response.text()
+                        logger.warning(
+                            f"Failed sending ping to {url}",
+                            status=response.status,
+                            data=data,
+                        )
+        except Exception as e:
+            logger.warning(f"Failed sending ping to {url}", failure=repr(e))
+
+    async def send_ping(self, target: str) -> None:
+        if not HEALTHCHECK_PING_ENABLED:
+            return
+
+        if target not in self.targets:
+            raise ValueError(f"Invalid target: {target}")
+
+        target_data = self.targets[target]
+
+        if (
+            target_data["latest_ping"] is None
+            or (datetime.now() - target_data["latest_ping"]).total_seconds()
+            >= target_data["interval"]
+        ):
+            target_data["latest_ping"] = datetime.now()
+
+            await self._send_post(target_data["url"])


### PR DESCRIPTION
### Acceptance Criteria

This feature will allow sending pings every time the data collector runs to an external uptime monitor service (see https://github.com/topics/uptime-monitor and https://github.com/topics/uptime for options, some of them are able to receive these pings)

There should be a feature-flag for this that is disabled by default.

The URL to send the ping to and the interval should be configurable, besides the api-key, if needed.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
