### PR TITLE
refactor: avoid usage of callbacks and use timeout for hathor-core client

### DIFF
--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 from urllib import parse
 
 import aiohttp
@@ -27,6 +27,8 @@ FEATURE_ENDPOINT = "/v1a/feature"
 
 
 class HathorCoreAsyncClient:
+    DEFAULT_TIMEOUT = 60  # seconds
+
     def __init__(self, domain: Optional[str] = None) -> None:
         """Client to make async requests
 
@@ -37,21 +39,24 @@ class HathorCoreAsyncClient:
         self.log = logger.new(client="async")
 
     async def get(
-        self, path: str, callback: Callable[[dict], None], params: Optional[dict] = None
+        self, path: str, params: Optional[dict] = None, timeout: Optional[float] = None
     ) -> None:
         """Make a get request async
 
         :param path: path to be requested
         :type path: str
-        :param callback: callback to be called with the response as argument
-        :type callback: Callable[[dict], None]
         :param params: params to be sent
         :type params: Optional[dict]
+        :param timeout: timeout in seconds
+        :type timeout: Optional[float]
         """
         url = parse.urljoin(f"https://{self.domain}", path)
 
+        if not timeout:
+            timeout = self.DEFAULT_TIMEOUT
+
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
                 async with session.get(url, params=params) as response:
                     if response.status > 299:
                         self.log.warning(
@@ -60,27 +65,30 @@ class HathorCoreAsyncClient:
                             status=response.status,
                             body=await response.text(),
                         )
-                    callback(await response.json())
+                    return await response.json()
         except Exception as e:
             self.log.error("hathor_core_error", path=path, error=repr(e))
-            callback({"error": repr(e)})
+            return {"error": repr(e)}
 
     async def post(
-        self, path: str, callback: Callable[[dict], None], body: Optional[dict] = None
+        self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None
     ) -> None:
         """Make a post request async
 
         :param path: path to be requested
         :type path: str
-        :param callback: callback to be called with the response as argument
-        :type callback: Callable[[dict], None]
         :param body: body to be sent encoded as json
         :type body: Optional[dict]
+        :param timeout: timeout in seconds
+        :type timeout: Optional[float]
         """
         url = parse.urljoin(f"https://{self.domain}", path)
 
+        if not timeout:
+            timeout = self.DEFAULT_TIMEOUT
+
         try:
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
                 async with session.post(url, json=body) as response:
                     if response.status > 299:
                         self.log.warning(
@@ -89,10 +97,10 @@ class HathorCoreAsyncClient:
                             status=response.status,
                             body=await response.text(),
                         )
-                    callback(await response.json())
+                    return await response.json()
         except Exception as e:
             self.log.error("hathor_core_error", path=path, error=repr(e))
-            callback({"error": repr(e)})
+            return {"error": repr(e)}
 
 
 class HathorCoreClient:

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -40,7 +40,7 @@ class HathorCoreAsyncClient:
 
     async def get(
         self, path: str, params: Optional[dict] = None, timeout: Optional[float] = None
-    ) -> None:
+    ) -> dict[Any, Any]:
         """Make a get request async
 
         :param path: path to be requested
@@ -56,7 +56,9 @@ class HathorCoreAsyncClient:
             timeout = self.DEFAULT_TIMEOUT
 
         try:
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as session:
                 async with session.get(url, params=params) as response:
                     if response.status > 299:
                         self.log.warning(
@@ -72,7 +74,7 @@ class HathorCoreAsyncClient:
 
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None
-    ) -> None:
+    ) -> dict[Any, Any]:
         """Make a post request async
 
         :param path: path to be requested
@@ -88,7 +90,9 @@ class HathorCoreAsyncClient:
             timeout = self.DEFAULT_TIMEOUT
 
         try:
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as session:
                 async with session.post(url, json=body) as response:
                     if response.status > 299:
                         self.log.warning(

--- a/gateways/node_gateway.py
+++ b/gateways/node_gateway.py
@@ -40,13 +40,10 @@ class NodeGateway:
         self.lambda_client = lambda_client or LambdaClient()
         self.log = logger.new()
 
-    async def get_node_status_async(self, callback: Callable[[dict], None]) -> None:
+    async def get_node_status_async(self) -> None:
         """Retrieve status from full-node
-
-        :param callback: method to be called passing response as param
-        :type callback: Callable[[dict], None]
         """
-        await self.hathor_core_async_client.get(STATUS_ENDPOINT, callback)
+        return await self.hathor_core_async_client.get(STATUS_ENDPOINT)
 
     def send_node_to_data_aggregator(self, payload: Node) -> int:
         """Invoke data-aggregator lambda passing node data to be aggregated

--- a/gateways/node_gateway.py
+++ b/gateways/node_gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Dict, List, Union
 
 from common.configuration import DATA_AGGREGATOR_LAMBDA_NAME, NODE_CACHE_TTL
 from common.errors import ConfigError

--- a/gateways/node_gateway.py
+++ b/gateways/node_gateway.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 from common.configuration import DATA_AGGREGATOR_LAMBDA_NAME, NODE_CACHE_TTL
 from common.errors import ConfigError
@@ -40,9 +40,8 @@ class NodeGateway:
         self.lambda_client = lambda_client or LambdaClient()
         self.log = logger.new()
 
-    async def get_node_status_async(self) -> None:
-        """Retrieve status from full-node
-        """
+    async def get_node_status_async(self) -> dict[Any, Any]:
+        """Retrieve status from full-node"""
         return await self.hathor_core_async_client.get(STATUS_ENDPOINT)
 
     def send_node_to_data_aggregator(self, payload: Node) -> int:

--- a/tests/unit/usecases/test_collect_nodes_statuses.py
+++ b/tests/unit/usecases/test_collect_nodes_statuses.py
@@ -28,7 +28,7 @@ class TestCollectNodesStatuses:
         ]
 
         node_gateway.get_node_status_async = AsyncMock(
-            side_effect=lambda x: x(HATHOR_CORE_MAINNET_GET_STATUS)
+            side_effect=lambda: HATHOR_CORE_MAINNET_GET_STATUS
         )
         with patch.object(
             NodeGateway, "get_node_status_async", new=node_gateway.get_node_status_async

--- a/usecases/collect_nodes_statuses.py
+++ b/usecases/collect_nodes_statuses.py
@@ -23,7 +23,8 @@ class CollectNodesStatuses:
         for node in HATHOR_NODES:
             client = HathorCoreAsyncClient(node)
             node_gateway = NodeGateway(hathor_core_async_client=client)
-            await node_gateway.get_node_status_async(self._send)
+            data = await node_gateway.get_node_status_async()
+            self._send(data)
 
     def _send(self, data: dict) -> None:
         if "error" in data:


### PR DESCRIPTION
### Acceptance Criteria
- We should avoid passing callbacks between functions if the same thing can be achieved without them
- We should use a default timeout and allow changing it when calling the methods of the `HathorCoreAsyncClient`


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
