### PR TITLE
fix: some type definitions don't work on Python 3.8

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,7 +11,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.8, 3.9]
     steps:
       - name: Checkout to branch
         # https://github.com/actions/checkout/releases/tag/v3.5.3

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 from urllib import parse
 
 import aiohttp
@@ -40,7 +40,7 @@ class HathorCoreAsyncClient:
 
     async def get(
         self, path: str, params: Optional[dict] = None, timeout: Optional[float] = None
-    ) -> dict[Any, Any]:
+    ) -> Dict[Any, Any]:
         """Make a get request async
 
         :param path: path to be requested
@@ -74,7 +74,7 @@ class HathorCoreAsyncClient:
 
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None
-    ) -> dict[Any, Any]:
+    ) -> Dict[Any, Any]:
         """Make a post request async
 
         :param path: path to be requested

--- a/gateways/node_gateway.py
+++ b/gateways/node_gateway.py
@@ -40,7 +40,7 @@ class NodeGateway:
         self.lambda_client = lambda_client or LambdaClient()
         self.log = logger.new()
 
-    async def get_node_status_async(self) -> dict[Any, Any]:
+    async def get_node_status_async(self) -> Dict[Any, Any]:
         """Retrieve status from full-node"""
         return await self.hathor_core_async_client.get(STATUS_ENDPOINT)
 


### PR DESCRIPTION
### Acceptance Criteria
- Fix the error below that was caught during tests on the dev environment.
- Make sure the CI will get things like this in the future, by making it run tests for Python 3.8 as well (we had it running only for 3.9, while our runtimes use 3.8.

```
Traceback (most recent call last):
  File "./daemons_runner.py", line 5, in <module>
    from daemons.data_collector import DataCollector
  File "/code/daemons/data_collector.py", line 8, in <module>
    from usecases.collect_nodes_statuses import CollectNodesStatuses
  File "/code/usecases/collect_nodes_statuses.py", line 6, in <module>
    from gateways.clients.hathor_core_client import HathorCoreAsyncClient
  File "/code/gateways/clients/hathor_core_client.py", line 29, in <module>
    class HathorCoreAsyncClient:
  File "/code/gateways/clients/hathor_core_client.py", line 43, in HathorCoreAsyncClient
    ) -> dict[Any, Any]:
TypeError: 'type' object is not subscriptable
```



### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
