### PR TITLE
chore: InvokeHandler tests

### DIFF
--- a/tests/unit/utils/wrappers/aws/test_invoke_handler.py
+++ b/tests/unit/utils/wrappers/aws/test_invoke_handler.py
@@ -1,0 +1,49 @@
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.wrappers.aws.invoke_handler import InvokeEvent, InvokeHandler, LambdaContext
+
+
+class TestInvokeHandler:
+    @pytest.fixture
+    def function_to_call(self) -> Callable[[InvokeEvent, LambdaContext, Any], dict]:
+        def function(
+            event: InvokeEvent, context: LambdaContext, *args: Any, **kwargs: Any
+        ) -> dict:
+            return {"success": True}
+
+        return function
+
+    @pytest.fixture
+    def function_to_call_with_exception(
+        self,
+    ) -> Callable[[InvokeEvent, LambdaContext, Any], dict]:
+        def function(
+            event: InvokeEvent, context: LambdaContext, *args: Any, **kwargs: Any
+        ) -> dict:
+            raise ValueError("Something went wrong")
+
+        return function
+
+    def test_invoke_handler_success(self, function_to_call):
+        invoke_handler = InvokeHandler()
+        wrapped_function = invoke_handler(function_to_call)
+
+        event = {"key": "value"}
+        context = MagicMock()
+        result = wrapped_function(event, context)
+
+        assert result == {"success": True}
+
+    def test_invoke_handler_exception(self, function_to_call_with_exception):
+        invoke_handler = InvokeHandler()
+        wrapped_function = invoke_handler(function_to_call_with_exception)
+
+        event = {"key": "value"}
+        context = MagicMock()
+
+        result = wrapped_function(event, context)
+
+        assert result == {"success": False, "error": "Something went wrong"}

--- a/utils/wrappers/aws/invoke_handler.py
+++ b/utils/wrappers/aws/invoke_handler.py
@@ -43,7 +43,8 @@ class InvokeHandler:
             except Exception as error:
                 logger.exception(error)
                 wrapped_error = dict(success=False)
-                wrapped_error.update(error.args)
+                if error.args:
+                    wrapped_error.update({"error": error.args[0]})
                 return wrapped_error
 
         return wrapper


### PR DESCRIPTION
### Acceptance Criteria
- We should have unit tests for the InvokeHandler class, which had 0% test coverage previously

The motivation for this is just to increase the project's test coverage


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
