### PR TITLE
fix: use latest python-healthchecklib

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1157,13 +1157,13 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-healthchecklib"
-version = "0.1.0"
+version = "0.1.1"
 description = "Opinionated healthcheck library"
 optional = false
 python-versions = ">=3.8.1,<4.0.0"
 files = [
-    {file = "python_healthchecklib-0.1.0-py3-none-any.whl", hash = "sha256:95d94fcae7f281adf16624014ae789dfa38d1be327cc38b02ee82bad70671f2f"},
-    {file = "python_healthchecklib-0.1.0.tar.gz", hash = "sha256:afa0572d37902c50232d99acf0065836082bb027109c9c98e8d5acfefd381595"},
+    {file = "python_healthchecklib-0.1.1-py3-none-any.whl", hash = "sha256:51ad9e7e782145977bf322cbe2095198a8b61473b09d43e79018e47483840d15"},
+    {file = "python_healthchecklib-0.1.1.tar.gz", hash = "sha256:bac6cdd9ef5825f6deb0cbe5f6d97260f3f402e111fc7fe2146444bdb77fd892"},
 ]
 
 [[package]]


### PR DESCRIPTION
### Acceptance Criteria
- The new version of python-healthchecklib fixes a bug that was affecting us. More info in https://github.com/HathorNetwork/python-healthcheck-lib/pull/2


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
