### PR TITLE
fix: avoid concurrent data collectors

### DIFF
--- a/daemons_runner.py
+++ b/daemons_runner.py
@@ -8,7 +8,9 @@ from daemons.data_collector import DataCollector
 async def data_collector() -> None:
     data_collector = DataCollector()
     while True:
-        asyncio.create_task(data_collector.run())
+        # This could take longer to run than the sleep time, so we wait for it to finish
+        await data_collector.run()
+        # Wait for 1 second before running again
         await asyncio.sleep(1)
 
 


### PR DESCRIPTION
### Acceptance Criteria

We should make sure we won't run the DataCollector daemon's logic concurrently in the asyncio event loop.

Each execution should wait for the previous one to finish before starting.

The way we did it before left the possibility of having several async tasks in the event loop at once, in case they took more than 1 second to finish.

For instance, supposing each of them took 5 seconds to finish, we would have 5 tasks running concurrently.

By looking at the number of concurrent executions in the Lambda that is called by this daemon, we can see that sometimes we had even 9 concurrent executions:

![image](https://github.com/HathorNetwork/hathor-explorer-service/assets/5041650/97d2ce0b-cc60-421d-913d-dbe3705952bd)

I suspect this could be related to high memory consumption in the daemon, but I'm not 100% sure. The fix looked beneficial anyway.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
