### PR TITLE
feat: support dag.best_block from node status

### DIFF
--- a/domain/network/network.py
+++ b/domain/network/network.py
@@ -134,6 +134,9 @@ class AggregatedNode:
     :param latest_timestamp: latest timestamp
     :type latest_timestamp: int
 
+    :param best_block: best block on that peer's chain
+    :type best_block: BlockInfo
+
     :param entrypoints: list of entrypoints if any
     :type entrypoints: List[str]
 
@@ -147,6 +150,7 @@ class AggregatedNode:
     uptime: float
     state: NodeState
     latest_timestamp: int
+    best_block: BlockInfo
     entrypoints: List[str]
     connected_peers: List[str]
 
@@ -166,6 +170,7 @@ class AggregatedNode:
             uptime=node.uptime,
             state=node.state,
             latest_timestamp=node.latest_timestamp,
+            best_block=node.best_block,
             entrypoints=node.entrypoints,
             connected_peers=[peer.id for peer in node.connected_peers],
         )

--- a/domain/network/node.py
+++ b/domain/network/node.py
@@ -120,6 +120,9 @@ class Node:
     :param latest_timestamp: Timestamp of the latest block of the node
     :type latest_timestamp: int
 
+    :param best_block: best block on that peer's chain
+    :type best_block: BlockInfo
+
     :param entrypoints: List of node entrypoints
     :type entrypoints: List[str]
 
@@ -138,6 +141,7 @@ class Node:
     uptime: float
     first_timestamp: int
     latest_timestamp: int
+    best_block: BlockInfo
     entrypoints: List[str]
     known_peers: List[str]
     connected_peers: List[Peer]
@@ -245,6 +249,10 @@ class Node:
             first_timestamp=status["dag"]["first_timestamp"],
             latest_timestamp=status["dag"]["latest_timestamp"],
             entrypoints=status["server"]["entrypoints"],
+            best_block=BlockInfo(
+                height=status["dag"]["best_block"]["height"],
+                id=status["dag"]["best_block"]["hash"],
+            ),
             known_peers=[id for id in peer_entrypoints.keys()],
             connected_peers=connected_peers,
         )

--- a/tests/fixtures/network_factory.py
+++ b/tests/fixtures/network_factory.py
@@ -83,6 +83,12 @@ class AggregatedNodeFactory(Factory):
     latest_timestamp = lazy_attribute(
         lambda o: fake.pyint(min_value=10_000, max_value=100_000)
     )
+    best_block = lazy_attribute(
+        lambda o: {
+            "height": fake.pyint(1_000_000, 5_000_000),
+            "id": fake.sha256(),
+        }
+    )
     entrypoints = lazy_attribute(
         lambda o: [
             f"tcp://{entrypoint()}" for i in range(fake.random_int(min=1, max=1))

--- a/tests/fixtures/node_factory.py
+++ b/tests/fixtures/node_factory.py
@@ -88,6 +88,12 @@ class NodeFactory(Factory):
     latest_timestamp = lazy_attribute(
         lambda o: fake.pyint(min_value=10_000, max_value=100_000)
     )
+    best_block = lazy_attribute(
+        lambda o: {
+            "height": fake.pyint(1_000_000, 5_000_000),
+            "id": fake.sha256(),
+        }
+    )
     entrypoints = lazy_attribute(
         lambda o: [
             f"tcp://{entrypoint()}" for i in range(fake.random_int(min=1, max=5))


### PR DESCRIPTION
### Acceptance Criteria

- Add `best_block` to the node model supporting `dag.best_block` from the status result. This is needed to calculate the sync progress for peers using sync-v2.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
