### PR TITLE
fix: legacy node data without best_block property

### DIFF
--- a/domain/network/network.py
+++ b/domain/network/network.py
@@ -150,7 +150,7 @@ class AggregatedNode:
     uptime: float
     state: NodeState
     latest_timestamp: int
-    best_block: BlockInfo
+    best_block: Optional[BlockInfo]
     entrypoints: List[str]
     connected_peers: List[str]
 


### PR DESCRIPTION
### Acceptance Criteria
- Fix by making the best_block property Optional.

Log of the error:
```txt
[ERROR] MissingValueError: missing value for field "nodes.best_block"
Traceback (most recent call last):
  File "/var/task/handlers/node_data_aggregator.py", line 10, in handle
    result_aggregate = aggregate_node_data.aggregate()
  File "/var/task/usecases/aggregate_node_data.py", line 39, in aggregate
    old_network = self.node_gateway.get_network()
  File "/var/task/gateways/node_gateway.py", line 111, in get_network
    return Network.from_dict(value)
  File "/var/task/domain/network/network.py", line 214, in from_dict
    return from_dict(
  File "/opt/python/dacite/core.py", line 63, in from_dict
    value = _build_value(type_=field.type, data=transformed_value, config=config)
  File "/opt/python/dacite/core.py", line 90, in _build_value
    return _build_value_for_collection(collection=type_, data=data, config=config)
  File "/opt/python/dacite/core.py", line 140, in _build_value_for_collection
    return data_type(_build_value(type_=item_type, data=item, config=config) for item in data)
  File "/opt/python/dacite/core.py", line 140, in <genexpr>
    return data_type(_build_value(type_=item_type, data=item, config=config) for item in data)
  File "/opt/python/dacite/core.py", line 92, in _build_value
    return from_dict(data_class=type_, data=data, config=config)
  File "/opt/python/dacite/core.py", line 75, in from_dict
    raise MissingValueError(field.name)
```

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
