### PR TITLE
chore: use hathor-core's health endpoint

### DIFF
--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -24,6 +24,7 @@ TRANSACTION_ENDPOINT = "/v1a/transaction"
 TX_ACC_WEIGHT_ENDPOINT = "/v1a/transaction_acc_weight"
 VERSION_ENDPOINT = "/v1a/version"
 FEATURE_ENDPOINT = "/v1a/feature"
+HEALTH_ENDPOINT = "/v1a/health"
 
 
 class HathorCoreAsyncClient:

--- a/gateways/healthcheck_gateway.py
+++ b/gateways/healthcheck_gateway.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from common.configuration import ELASTIC_INDEX
 from gateways.clients.cache_client import CacheClient
 from gateways.clients.elastic_search_client import ElasticSearchClient
-from gateways.clients.hathor_core_client import VERSION_ENDPOINT, HathorCoreAsyncClient
+from gateways.clients.hathor_core_client import HEALTH_ENDPOINT, HathorCoreAsyncClient
 from gateways.clients.wallet_service_db_client import WalletServiceDBClient
 
 # The default lambda timeout for the Healtcheck Lambda is set to
@@ -32,11 +32,11 @@ class HealthcheckGateway:
             wallet_service_db_client or WalletServiceDBClient()
         )
 
-    async def get_hathor_core_version(self) -> Optional[dict]:
-        """Retrieve hathor-core version information"""
+    async def get_hathor_core_health(self) -> Optional[dict]:
+        """Retrieve hathor-core health information"""
 
         return await self.hathor_core_async_client.get(
-            VERSION_ENDPOINT, timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS
+            HEALTH_ENDPOINT, timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS
         )
 
     def ping_redis(self) -> bool:

--- a/tests/unit/gateways/test_healthcheck_gateway.py
+++ b/tests/unit/gateways/test_healthcheck_gateway.py
@@ -18,15 +18,15 @@ class TestHealthcheckGateway(unittest.IsolatedAsyncioTestCase):
             wallet_service_db_client=self.wallet_service_db_client,
         )
 
-    async def test_get_hathor_core_version(self):
-        async def mock_get_hathor_core_version(endpoint, **kwargs):
-            return {"version": "0.39.0"}
+    async def test_get_hathor_core_health(self):
+        async def mock_get_hathor_core_health(endpoint, **kwargs):
+            return {"status": "pass"}
 
-        self.hathor_core_async_client.get.side_effect = mock_get_hathor_core_version
-        result = await self.healthcheck_gateway.get_hathor_core_version()
-        self.assertEqual(result, {"version": "0.39.0"})
+        self.hathor_core_async_client.get.side_effect = mock_get_hathor_core_health
+        result = await self.healthcheck_gateway.get_hathor_core_health()
+        self.assertEqual(result, {"status": "pass"})
         self.hathor_core_async_client.get.assert_called_once_with(
-            "/v1a/version", timeout=5
+            "/v1a/health", timeout=5
         )
 
     def test_ping_redis(self):

--- a/tests/unit/usecases/test_healthcheck.py
+++ b/tests/unit/usecases/test_healthcheck.py
@@ -18,11 +18,11 @@ class TestGetHealthcheck(unittest.TestCase):
             )
 
     def test_all_components_healthy(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = True
@@ -80,11 +80,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_hathor_core_returns_error(self):
-        async def mock_get_hathor_core_version():
+        async def mock_get_hathor_core_health():
             return {"error": "Unable to connect"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = True
@@ -142,11 +142,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_wallet_service_db_raises_exception(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.side_effect = Exception(
             "Unable to connect"
@@ -206,11 +206,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_wallet_service_db_reports_unhealthy(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (
             False,
@@ -271,11 +271,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_redis_raises_exception(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.side_effect = Exception(
@@ -335,11 +335,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_redis_reports_unhealthy(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = False
@@ -397,11 +397,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_elasticsearch_raises_exception(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = True
@@ -459,11 +459,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_elasticsearch_reports_unhealthy(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = True
@@ -521,11 +521,11 @@ class TestGetHealthcheck(unittest.TestCase):
         )
 
     def test_elasticsearch_report_yellow(self):
-        async def mock_get_hathor_core_version():
-            return {"version": "0.38.0"}
+        async def mock_get_hathor_core_health():
+            return {"status": "pass"}
 
-        self.mock_healthcheck_gateway.get_hathor_core_version.side_effect = (
-            mock_get_hathor_core_version
+        self.mock_healthcheck_gateway.get_hathor_core_health.side_effect = (
+            mock_get_hathor_core_health
         )
         self.mock_healthcheck_gateway.ping_wallet_service_db.return_value = (True, "1")
         self.mock_healthcheck_gateway.ping_redis.return_value = True


### PR DESCRIPTION
### Acceptance Criteria
- We should use the new hathor-core's health endpoint to build our own health response. Previously, the `/version` endpoint was being used just because the health endpoint hadn't been released yet.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
