### PR TITLE
fix: use better identification for api-keys

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ provider:
     Stage: "${self:custom.stage}"
   apiGateway:
     apiKeys:
-      - ${self:custom.stage}-healthcheck-api-key
+      - explorer-service-${self:custom.stage}-healthcheck-api-key
   logs:
     restApi: # TODO: add data to make the serverless create this role by itself
       role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch


### PR DESCRIPTION
### Acceptance Criteria
- We should make sure there is a `explorer-service-` prefix in the the names of api-keys deployed in API Gateway, to make sure they won't conflict with other services trying to create API Keys.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
