### PR TITLE
fix: function name is bigger than 64 chars

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -693,7 +693,7 @@ functions:
               - name: request.querystring.count
               - name: request.header.origin
 
-  node_api_nc_blueprint_information:
+  node_api_nc_blueprint_info:
     handler: handlers/node_api.nc_blueprint_information
     maximumRetryAttempts: 0
     package:


### PR DESCRIPTION
### Motivation

The lambda deploy failed because the lambda function name after adding the prefix of the app and staging was bigger than 64 characters (`hathor-explorer-service-mainnet-node_api_nc_blueprint_information` has 65 chars).

### Acceptance Criteria
- Function name (`node_api_nc_blueprint_information`) must have 1 less char.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
