### PR TITLE
fix: hathor-core healthcheck

### DIFF
--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -43,7 +43,11 @@ class HathorCoreAsyncClient:
         self.log = logger.new(client="async")
 
     async def get(
-        self, path: str, params: Optional[dict] = None, timeout: Optional[float] = None
+        self,
+        path: str,
+        params: Optional[dict] = None,
+        timeout: Optional[float] = None,
+        content_type: Optional[str] = "application/json",
     ) -> Dict[Any, Any]:
         """Make a get request async
 
@@ -71,7 +75,7 @@ class HathorCoreAsyncClient:
                             status=response.status,
                             body=await response.text(),
                         )
-                    return await response.json()
+                    return await response.json(content_type=content_type)
         except Exception as e:
             self.log.error("hathor_core_error", path=path, error=repr(e))
             return {"error": repr(e)}

--- a/gateways/healthcheck_gateway.py
+++ b/gateways/healthcheck_gateway.py
@@ -38,9 +38,10 @@ class HealthcheckGateway:
         return await self.hathor_core_async_client.get(
             # XXX: We set the expected content_type to None because hathor-core was returning 'text/html' instead of 'application/json'
             # This will be fixed in the next release of hathor-core (v0.63.0)
+            # None is better here to avoid having to sync the releases of hathor-core and explorer-service
             HEALTH_ENDPOINT,
             timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS,
-            content_type="text/html",
+            content_type=None,
         )
 
     def ping_redis(self) -> bool:

--- a/gateways/healthcheck_gateway.py
+++ b/gateways/healthcheck_gateway.py
@@ -36,7 +36,11 @@ class HealthcheckGateway:
         """Retrieve hathor-core health information"""
 
         return await self.hathor_core_async_client.get(
-            HEALTH_ENDPOINT, timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS
+            # XXX: We set the expected content_type to None because hathor-core was returning 'text/html' instead of 'application/json'
+            # This will be fixed in the next release of hathor-core (v0.63.0)
+            HEALTH_ENDPOINT,
+            timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS,
+            content_type="text/html",
         )
 
     def ping_redis(self) -> bool:

--- a/tests/unit/gateways/test_healthcheck_gateway.py
+++ b/tests/unit/gateways/test_healthcheck_gateway.py
@@ -26,7 +26,7 @@ class TestHealthcheckGateway(unittest.IsolatedAsyncioTestCase):
         result = await self.healthcheck_gateway.get_hathor_core_health()
         self.assertEqual(result, {"status": "pass"})
         self.hathor_core_async_client.get.assert_called_once_with(
-            "/v1a/health", timeout=5
+            "/v1a/health", timeout=5, content_type=None
         )
 
     def test_ping_redis(self):


### PR DESCRIPTION
### Acceptance Criteria
- We should expect to receive a response with Content-Type `text/html` from hathor-core's health endpoint, and make aiohttp parse it without errors.
- After https://github.com/HathorNetwork/hathor-core/pull/1110 gets released, we will be able to revert this change. I preferred to do it instead of waiting for hathor-core, because it could take too long.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
