### PR TITLE
feat: truncate children in tx detail API to return at most 100 elements

### DIFF
--- a/common/configuration.py
+++ b/common/configuration.py
@@ -110,3 +110,6 @@ HEALTHCHECK_ELASTICSEARCH_ENABLED = config(
 HEALTHCHECK_REDIS_ENABLED = config(
     "HEALTHCHECK_REDIS_ENABLED", default=False, cast=bool
 )
+
+# API configuration
+MAX_TX_CHILDREN = config("MAX_TX_CHILDREN", default=100)

--- a/handlers/node_api.py
+++ b/handlers/node_api.py
@@ -176,6 +176,12 @@ def get_transaction(
     if id is None:
         raise ApiError("invalid_parameters")
     response = node_api.get_transaction(id)
+    # It does not make sense to show in the explorer thousands of children.
+    # The full node will continue returning the correct data but in the explorer
+    # service we will truncate it and return only the latest 100 to show in the UI
+    # (it might even be more than we should, maybe we should paginate in the future)
+    if 'meta' in response and 'children' in response['meta']:
+        response['meta']['children'] = response['meta']['children'][-100:]
 
     return {
         "statusCode": 200,

--- a/handlers/node_api.py
+++ b/handlers/node_api.py
@@ -180,8 +180,8 @@ def get_transaction(
     # The full node will continue returning the correct data but in the explorer
     # service we will truncate it and return only the latest 100 to show in the UI
     # (it might even be more than we should, maybe we should paginate in the future)
-    if 'meta' in response and 'children' in response['meta']:
-        response['meta']['children'] = response['meta']['children'][-100:]
+    if response is not None and "meta" in response and "children" in response["meta"]:
+        response["meta"]["children"] = response["meta"]["children"][-100:]
 
     return {
         "statusCode": 200,

--- a/handlers/node_api.py
+++ b/handlers/node_api.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from aws_lambda_context import LambdaContext
 
+from common.configuration import MAX_TX_CHILDREN
 from common.errors import ApiError
 from usecases.node_api import NodeApi
 from utils.wrappers.aws.api_gateway import ApiGateway, ApiGatewayEvent
@@ -178,10 +179,10 @@ def get_transaction(
     response = node_api.get_transaction(id)
     # It does not make sense to show in the explorer thousands of children.
     # The full node will continue returning the correct data but in the explorer
-    # service we will truncate it and return only the latest 100 to show in the UI
+    # service we will truncate it and return only the latest MAX_TX_CHILDREN to show in the UI
     # (it might even be more than we should, maybe we should paginate in the future)
     if response is not None and "meta" in response and "children" in response["meta"]:
-        response["meta"]["children"] = response["meta"]["children"][-100:]
+        response["meta"]["children"] = response["meta"]["children"][-MAX_TX_CHILDREN:]
 
     return {
         "statusCode": 200,


### PR DESCRIPTION
### Motivation

There are networks with low quantity of transactions that remain for a long time without transactions. Because of that, the latest tx keeps being used by blocks as parent, so it list of children increases a lot. The explorer service lambda returns 502 for any response bigger than 6mb, so some transactions (https://explorer.testnet.hathor.network/transaction/00e161a6b0bee1781ea9300680913fb76fd0fac4acab527cd9626cc1514abdc9, for example) were not being loaded.

There's no reason for the UI to receive a list of 193k elements. We should paginate it, if we decide that it's important to show all of them. For now, we are truncating it and returning the latest 100 elements.

### Acceptance Criteria
- Truncate children list in the tx detail API to return at most 100 elements.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
