### PR TITLE
chore: bump to v0.18.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hathor-explorer-service",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hathor-explorer-service",
-      "version": "0.18.1",
+      "version": "0.18.2",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-cli": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hathor-explorer-service",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Hathor Explorer Service Serverless deps",
   "dependencies": {
     "@apidevtools/swagger-cli": "^4.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hathor-explorer-service"
-version = "0.18.1"
+version = "0.18.2"
 description = ""
 authors = ["Hathor Labs <contact@hathor.network>"]
 license = "MIT"


### PR DESCRIPTION
### Acceptance Criteria
- Bump explorer service to v0.18.2


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
