### PR TITLE
chore: update ekvilibro-testnet redis config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
       hathor_nodes: https://node-side-dag.ekvilibro-testnet.hathor.network
       redis_key_prefix: hathor-explorer-service-ekvilibro-testnet
       redis_port: 6379
-      redis_db: 0
+      redis_db: 2
       metadata_bucket: hathor-explorer-metadata-ekvilibro-testnet
       cors_allowed_regex: https?:\/\/([a-z0-9\-]*\.){0,5}hathor\.network
       elastic_index: ekvilibro-testnet-token


### PR DESCRIPTION
### Acceptance Criteria
- The used redis DB should now be number `2`

### Motivation

I made changes in the infra so that we have a shared Redis cluster for both ekvilibro-testnet and ekvilibro-mainnet, instead of separated ones. The host is only changed in the secrets, so it doesn't appear here. The only change needed here was the DB

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
