### PR TITLE
feat: add CloudWatch IAM role, shielded deploy target, and CI for testnet-shielded-outputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,3 +256,35 @@ jobs:
       slack_notify: true
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  deploy-testnet-shielded-outputs:
+    needs: [init, dependencies]
+
+    if: ${{ needs.init.outputs.environment == 'testnet' }}
+
+    uses: ./.github/workflows/deploy-reusable.yml
+    with:
+      aws_region: eu-central-1
+      aws_iam_role: arn:aws:iam::264627803661:role/ExplorerServiceGitHubActionsRole
+      aws_secret_arn: ExplorerService/testnet-shielded-outputs
+      serverless_stage: shielded
+      docker_image_tag: testnet-shielded-outputs-${{ github.sha }}-${{ needs.init.outputs.timestamp }}
+      api_port: 3001
+      hathor_core_url: https://node1.shielded-outputs.testnet.hathor.network
+      hathor_nodes: https://node1.shielded-outputs.testnet.hathor.network
+      redis_key_prefix: hathor-explorer-service-shielded
+      redis_port: 6379
+      redis_db: 0
+      metadata_bucket: hathor-explorer-metadata-testnet-shielded-outputs
+      cors_allowed_regex: https?://([a-z0-9\-]*\.)*testnet\.hathor\.network
+      elastic_index: testnet-shielded-outputs-token
+      elastic_tx_index: testnet-shielded-outputs-tx
+      elastic_token_balances_index: testnet-shielded-outputs-token_balances
+      healthcheck_hathor_core_enabled: true
+      healthcheck_wallet_service_db_enabled: true
+      healthcheck_elasticsearch_enabled: true
+      healthcheck_redis_enabled: true
+      serverless_deploy_prefix: explorer-svc
+      slack_notify: true
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/Makefile
+++ b/Makefile
@@ -111,3 +111,7 @@ validate_docs:
 .PHONY: bundle_docs
 bundle_docs:
 	npx swagger-cli bundle -o openapi.yml -t yaml text/api-docs.yml
+
+.PHONY: deploy-lambdas-shielded
+deploy-lambdas-shielded:
+	AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stage shielded --region eu-central-1 --aws-profile testnet-shielded-outputs

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,12 @@ test:
 stage=dev
 # The "AWS_SDK_LOAD_CONFIG=1" is needed to load the AWS credentials from the ~/.aws/config file
 # This is part of the solution to make it work with `aws sso login`
+.PHONY: ensure-poetry-export-plugin
+ensure-poetry-export-plugin:
+	@poetry self show plugins 2>/dev/null | grep -q poetry-plugin-export || poetry self add poetry-plugin-export
+
 .PHONY: deploy-lambdas
-deploy-lambdas:
+deploy-lambdas: ensure-poetry-export-plugin
 	AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stage $(stage) --region eu-central-1
 
 .PHONY: deploy-lambdas-ci
@@ -70,11 +74,11 @@ deploy-lambdas-ci:
 	npx serverless deploy --stage $(stage) --region eu-central-1
 
 .PHONY: deploy-lambdas-playground
-deploy-lambdas-playground:
+deploy-lambdas-playground: ensure-poetry-export-plugin
 	AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stage playground --region eu-central-1 --aws-profile testnet-playground
 
 .PHONY: install
-install:
+install: ensure-poetry-export-plugin
 	npm install
 	poetry install
 
@@ -111,3 +115,7 @@ validate_docs:
 .PHONY: bundle_docs
 bundle_docs:
 	npx swagger-cli bundle -o openapi.yml -t yaml text/api-docs.yml
+
+.PHONY: deploy-lambdas-shielded
+deploy-lambdas-shielded: ensure-poetry-export-plugin
+	AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stage shielded --region eu-central-1 --aws-profile testnet-shielded-outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ description = ""
 authors = ["Hathor Labs <contact@hathor.network>"]
 license = "MIT"
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 redis = "^3.5.3"

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,8 +31,8 @@ provider:
     binaryMediaTypes:
       - 'image/*'
   logs:
-    restApi: # TODO: add data to make the serverless create this role by itself
-      role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch
+    restApi:
+      role: !GetAtt ApiGatewayCloudWatchLogsRole.Arn
   vpc:
     securityGroupIds:
       - ${env:AWS_VPC_DEFAULT_SG_ID}
@@ -1025,3 +1025,23 @@ functions:
           throttling:
             maxRequestsPerSecond: 2
             maxConcurrentRequests: 2
+
+resources:
+  Resources:
+    ApiGatewayCloudWatchLogsRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: apigateway.amazonaws.com
+              Action: sts:AssumeRole
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+    CustomApiGatewayAccountCloudWatchRole:
+      Type: AWS::ApiGateway::Account
+      DependsOn: ApiGatewayCloudWatchLogsRole
+      Properties:
+        CloudWatchRoleArn: !GetAtt ApiGatewayCloudWatchLogsRole.Arn

--- a/serverless.yml
+++ b/serverless.yml
@@ -21,7 +21,7 @@ provider:
     apiKeys:
       - explorer-service-${self:custom.stage}-healthcheck-api-key
   logs:
-    restApi: # TODO: add data to make the serverless create this role by itself
+    restApi:
       role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch
   vpc:
     securityGroupIds:
@@ -988,3 +988,21 @@ functions:
           throttling:
             maxRequestsPerSecond: 2
             maxConcurrentRequests: 2
+
+resources:
+  Resources:
+    ApiGatewayCloudWatchLogsRole:
+      Type: AWS::IAM::Role
+      Properties:
+        RoleName: APIGatewayPushLogsToCloudWatch
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service: apigateway.amazonaws.com
+              Action: sts:AssumeRole
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+    CustomApiGatewayAccountCloudWatchRole:
+      DependsOn: ApiGatewayCloudWatchLogsRole

--- a/serverless.yml
+++ b/serverless.yml
@@ -32,7 +32,7 @@ provider:
       - 'image/*'
   logs:
     restApi:
-      role: !GetAtt ApiGatewayCloudWatchLogsRole.Arn
+      roleManagedExternally: true
   vpc:
     securityGroupIds:
       - ${env:AWS_VPC_DEFAULT_SG_ID}
@@ -1025,23 +1025,3 @@ functions:
           throttling:
             maxRequestsPerSecond: 2
             maxConcurrentRequests: 2
-
-resources:
-  Resources:
-    ApiGatewayCloudWatchLogsRole:
-      Type: AWS::IAM::Role
-      Properties:
-        AssumeRolePolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Principal:
-                Service: apigateway.amazonaws.com
-              Action: sts:AssumeRole
-        ManagedPolicyArns:
-          - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
-    CustomApiGatewayAccountCloudWatchRole:
-      Type: AWS::ApiGateway::Account
-      DependsOn: ApiGatewayCloudWatchLogsRole
-      Properties:
-        CloudWatchRoleArn: !GetAtt ApiGatewayCloudWatchLogsRole.Arn


### PR DESCRIPTION
Depends on: https://github.com/HathorNetwork/ops-tools/pull/1344

## Summary

This PR adds infrastructure and CI improvements for the `testnet-shielded-outputs` environment:

### CloudWatch IAM Role (`serverless.yml`)
The `APIGatewayPushToCloudWatchLogs` IAM role was previously required to exist manually before deployment. This PR adds it as a CloudFormation resource in the `resources` section, so Serverless Framework creates/manages it automatically. The TODO comment noting this gap has been removed.

### Shielded Deploy Target (`Makefile`)
Adds a `deploy-lambdas-shielded` Makefile target to streamline deployments to the `shielded` stage:
- Region: `eu-central-1`
- AWS profile: `testnet-shielded-outputs`

### CI/CD for testnet-shielded-outputs (`.github/workflows/deploy.yml`)
Adds automated deployment workflow for the `testnet-shielded-outputs` environment.

### Fix: Poetry Export (`pyproject.toml`, `Makefile`)
Ensures `poetry` can properly export dependencies for deployment.

## How to deploy
```bash
make deploy-lambdas-shielded
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added deployment support for a new "shielded" testnet environment and CI workflow to run it.
  * Improved logging configuration for API gateway deployments to allow externally managed roles.
  * Updated packaging tooling to declare export-plugin support, ensuring consistent build/export behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->