### PR TITLE
Add metadata/icon endpoint (S3 icons) and binary PNG support

### DIFF
--- a/gateways/clients/s3_client.py
+++ b/gateways/clients/s3_client.py
@@ -32,6 +32,22 @@ class S3Client:
             # TODO: Add log here
             return None
 
+    def load_file_bytes(self, bucket: str, file: str) -> Union[bytes, None]:
+        """Loads raw bytes from a file in s3 bucket (for binary files such as images)
+
+        :param bucket: bucket name
+        :type bucket: str
+        :param file: file path
+        :type file: str
+        :return: the raw file bytes or None if not found
+        :rtype: bytes | None
+        """
+        try:
+            response = self.client.get_object(Bucket=bucket, Key=file)
+            return response["Body"].read()
+        except self.client.exceptions.NoSuchKey:
+            return None
+
     def upload_file(self, bucket: str, file: str, content: str) -> dict:
         """Writes a string to a file in the storage.
 

--- a/gateways/metadata_gateway.py
+++ b/gateways/metadata_gateway.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Optional, Union
 
 from common.configuration import METADATA_BUCKET
 from common.errors import ConfigError
@@ -26,6 +26,18 @@ class MetadataGateway:
         if metadata is None:
             return None
         return json.dumps({id: metadata})
+
+    def get_icon_metadata(self, id: str) -> Optional[bytes]:
+        """Retrieve icon image bytes from a png file stored in s3
+
+        :param id: token/transaction hash id
+        :type id: str
+        :raises ConfigError: The name of the bucket used to store files must be on config
+        :return: raw PNG bytes or None if not found
+        :rtype: bytes | None
+        """
+        metadata_bucket = self._metadata_bucket()
+        return self.s3_client.load_file_bytes(metadata_bucket, f"icons/{id}.png")
 
     def put_dag_metadata(self, id: str, contents: str) -> None:
         """Update dag metadata on a json file stored in s3, with contents received via parameter

--- a/gateways/metadata_gateway.py
+++ b/gateways/metadata_gateway.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Union
+from typing import Optional
 
 from common.configuration import METADATA_BUCKET
 from common.errors import ConfigError

--- a/gateways/metadata_gateway.py
+++ b/gateways/metadata_gateway.py
@@ -27,17 +27,17 @@ class MetadataGateway:
             return None
         return json.dumps({id: metadata})
 
-    def get_icon_metadata(self, id: str) -> Optional[bytes]:
+    def get_icon_metadata(self, icon_id: str) -> Optional[bytes]:
         """Retrieve icon image bytes from a png file stored in s3
 
-        :param id: token/transaction hash id
-        :type id: str
+        :param icon_id: token/transaction hash id
+        :type icon_id: str
         :raises ConfigError: The name of the bucket used to store files must be on config
         :return: raw PNG bytes or None if not found
         :rtype: bytes | None
         """
         metadata_bucket = self._metadata_bucket()
-        return self.s3_client.load_file_bytes(metadata_bucket, f"icons/{id}.png")
+        return self.s3_client.load_file_bytes(metadata_bucket, f"icons/{icon_id}.png")
 
     def put_dag_metadata(self, id: str, contents: str) -> None:
         """Update dag metadata on a json file stored in s3, with contents received via parameter

--- a/handlers/icon_metadata_handler.py
+++ b/handlers/icon_metadata_handler.py
@@ -20,6 +20,8 @@ def handle_get(
 
     if response is None:
         raise ApiError("not_found")
+    if not isinstance(response, bytes):
+        raise ApiError("internal_error")
 
     return {
         "statusCode": 200,

--- a/handlers/icon_metadata_handler.py
+++ b/handlers/icon_metadata_handler.py
@@ -1,0 +1,29 @@
+import base64
+from typing import Optional
+
+from aws_lambda_context import LambdaContext
+
+from common.errors import ApiError
+from usecases.metadata import Metadata
+from utils.wrappers.aws.api_gateway import ApiGateway, ApiGatewayEvent
+
+
+@ApiGateway()
+def handle_get(
+    event: ApiGatewayEvent, _context: LambdaContext, metadata: Optional[Metadata] = None
+) -> dict:
+    metadata = metadata or Metadata()
+    if "id" not in event.query:
+        raise ApiError("invalid_parameters")
+    hash = event.query["id"]
+    response = metadata.get("icon", hash)
+
+    if response is None:
+        raise ApiError("not_found")
+
+    return {
+        "statusCode": 200,
+        "body": base64.b64encode(response).decode(),
+        "isBase64Encoded": True,
+        "headers": {"Content-Type": "image/png"},
+    }

--- a/handlers/icon_metadata_handler.py
+++ b/handlers/icon_metadata_handler.py
@@ -15,8 +15,8 @@ def handle_get(
     metadata = metadata or Metadata()
     if "id" not in event.query:
         raise ApiError("invalid_parameters")
-    hash = event.query["id"]
-    response = metadata.get("icon", hash)
+    icon_id = event.query["id"]
+    response = metadata.get("icon", icon_id)
 
     if response is None:
         raise ApiError("not_found")

--- a/serverless.yml
+++ b/serverless.yml
@@ -424,7 +424,7 @@ functions:
           cors: true
           caching:
             enabled: true
-            ttlInSeconds: 300
+            ttlInSeconds: 86400  # one day cache, as icons don't change often
             cacheKeyParameters:
               - name: request.querystring.id
               - name: request.header.origin

--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,16 @@ provider:
   apiGateway:
     apiKeys:
       - explorer-service-${self:custom.stage}-healthcheck-api-key
+    # API Gateway decodes Lambda responses marked as base64 only when the
+    # request's `Accept` header matches one of the configured binary media types.
+    #
+    # Clients (wget, curl) should send `Accept: image/png` to receive raw PNG
+    # bytes. We could include '*/*' here for broader compatibility so generic clients
+    # would also receive binary responses, but that could affect how API Gateway treats
+    # other responses if Content-Type headers are missing. We preferred letting the clients
+    # set the client `Accept` header.
+    binaryMediaTypes:
+      - 'image/png'
   logs:
     restApi: # TODO: add data to make the serverless create this role by itself
       role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch
@@ -37,6 +47,11 @@ provider:
         - s3:PutObject
       Resource:
         - arn:aws:s3:::${env:METADATA_BUCKET}/dag/*
+    - Effect: Allow
+      Action:
+        - s3:GetObject
+      Resource:
+        - arn:aws:s3:::${env:METADATA_BUCKET}/icons/*
   environment:
     HATHOR_CORE_URL: ${env:HATHOR_CORE_URL}
     HATHOR_NODES: ${env:HATHOR_NODES}
@@ -392,6 +407,26 @@ functions:
         - 'handlers/dag_metadata_handler.py'
     layers:
       - { Ref: PythonRequirementsLambdaLayer }
+
+  get_icon_metadata_handler:
+    handler: handlers/icon_metadata_handler.handle_get
+    memorySize: 256
+    package:
+      patterns:
+        - 'handlers/icon_metadata_handler.py'
+    layers:
+      - { Ref: PythonRequirementsLambdaLayer }
+    events:
+      - http:
+          path: metadata/icon
+          method: get
+          cors: true
+          caching:
+            enabled: true
+            ttlInSeconds: 300
+            cacheKeyParameters:
+              - name: request.querystring.id
+              - name: request.header.origin
 
   node_api_get_address_balance:
     handler: handlers/node_api.get_address_balance

--- a/serverless.yml
+++ b/serverless.yml
@@ -29,7 +29,7 @@ provider:
     # other responses if Content-Type headers are missing. We preferred letting the clients
     # set the client `Accept` header.
     binaryMediaTypes:
-      - 'image/png'
+      - 'image/*'
   logs:
     restApi: # TODO: add data to make the serverless create this role by itself
       role: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/APIGatewayPushLogsToCloudWatch
@@ -45,6 +45,7 @@ provider:
     - Effect: Allow
       Action:
         - s3:PutObject
+        - s3:GetObject
       Resource:
         - arn:aws:s3:::${env:METADATA_BUCKET}/dag/*
     - Effect: Allow
@@ -427,6 +428,7 @@ functions:
             cacheKeyParameters:
               - name: request.querystring.id
               - name: request.header.origin
+              - name: request.header.Accept
 
   node_api_get_address_balance:
     handler: handlers/node_api.get_address_balance

--- a/tests/unit/gateways/clients/test_s3_client.py
+++ b/tests/unit/gateways/clients/test_s3_client.py
@@ -43,3 +43,35 @@ class TestS3Client:
         result = s3_client.load_file("kicked", "broken")
 
         assert result is None
+
+    @patch("gateways.clients.s3_client.S3_ENDPOINT", "http://lambda.invoke.endpoint")
+    def test_load_file_bytes(self):
+        s3_client = S3Client()
+
+        stubber = Stubber(s3_client.client)
+
+        raw_bytes = b"\x89PNG\r\n\x1a\n"
+        s3_expected_params = {"Bucket": "head", "Key": "icons/token.png"}
+        s3_response = {"Body": StreamingBody(BytesIO(raw_bytes), len(raw_bytes))}
+        stubber.add_response("get_object", s3_response, s3_expected_params)
+        stubber.activate()
+
+        result = s3_client.load_file_bytes("head", "icons/token.png")
+
+        assert result == raw_bytes
+
+    @patch("gateways.clients.s3_client.S3_ENDPOINT", None)
+    def test_load_file_bytes_error(self):
+        s3_client = S3Client()
+
+        stubber = Stubber(s3_client.client)
+
+        s3_expected_params = {"Bucket": "head", "Key": "icons/missing.png"}
+        stubber.add_client_error(
+            "get_object", "NoSuchKey", expected_params=s3_expected_params
+        )
+        stubber.activate()
+
+        result = s3_client.load_file_bytes("head", "icons/missing.png")
+
+        assert result is None

--- a/tests/unit/gateways/test_metadata_gateway.py
+++ b/tests/unit/gateways/test_metadata_gateway.py
@@ -112,7 +112,9 @@ class TestMetadataGateway:
 
         result = gateway.get_icon_metadata(hash_id)
 
-        s3_client.load_file_bytes.assert_called_once_with("metadata", f"icons/{hash_id}.png")
+        s3_client.load_file_bytes.assert_called_once_with(
+            "metadata", f"icons/{hash_id}.png"
+        )
         assert result == icon_bytes
 
     @patch("gateways.metadata_gateway.METADATA_BUCKET", "metadata")
@@ -123,7 +125,9 @@ class TestMetadataGateway:
 
         result = gateway.get_icon_metadata("some-id")
 
-        s3_client.load_file_bytes.assert_called_once_with("metadata", "icons/some-id.png")
+        s3_client.load_file_bytes.assert_called_once_with(
+            "metadata", "icons/some-id.png"
+        )
         assert result is None
 
     @patch("gateways.metadata_gateway.METADATA_BUCKET", None)

--- a/tests/unit/gateways/test_metadata_gateway.py
+++ b/tests/unit/gateways/test_metadata_gateway.py
@@ -100,3 +100,35 @@ class TestMetadataGateway:
 
         result = gateway._get_metadata("obj_name")
         assert result is None
+
+    @patch("gateways.metadata_gateway.METADATA_BUCKET", "metadata")
+    def test_get_icon_metadata(self, s3_client):
+        icon_bytes = b"\x89PNG\r\n\x1a\n"
+        hash_id = "0000000073dd17b4c0f4670da70b7a2c9a07a629e38b9a47196c0fe7335f333e"
+
+        s3_client.load_file_bytes = MagicMock(return_value=icon_bytes)
+
+        gateway = MetadataGateway(s3_client=s3_client)
+
+        result = gateway.get_icon_metadata(hash_id)
+
+        s3_client.load_file_bytes.assert_called_once_with("metadata", f"icons/{hash_id}.png")
+        assert result == icon_bytes
+
+    @patch("gateways.metadata_gateway.METADATA_BUCKET", "metadata")
+    def test_get_icon_metadata_return_none(self, s3_client):
+        s3_client.load_file_bytes = MagicMock(return_value=None)
+
+        gateway = MetadataGateway(s3_client=s3_client)
+
+        result = gateway.get_icon_metadata("some-id")
+
+        s3_client.load_file_bytes.assert_called_once_with("metadata", "icons/some-id.png")
+        assert result is None
+
+    @patch("gateways.metadata_gateway.METADATA_BUCKET", None)
+    def test_get_icon_metadata_raises_exception(self):
+        gateway = MetadataGateway()
+
+        with raises(ConfigError, match=r"No bucket name in config"):
+            gateway.get_icon_metadata("some-id")

--- a/tests/unit/usecases/test_metadata.py
+++ b/tests/unit/usecases/test_metadata.py
@@ -28,6 +28,27 @@ class TestMetadata:
 
         assert result is None
 
+    def test_get_for_icon(self, metadata_gateway):
+        icon_bytes = b"\x89PNG\r\n\x1a\n"
+        metadata_gateway.get_icon_metadata = MagicMock(return_value=icon_bytes)
+
+        get_metadata = Metadata(metadata_gateway)
+
+        result = get_metadata.get("icon", "some-id")
+
+        metadata_gateway.get_icon_metadata.assert_called_once_with("some-id")
+        assert result == icon_bytes
+
+    def test_get_icon_return_none(self, metadata_gateway):
+        metadata_gateway.get_icon_metadata = MagicMock(return_value=None)
+
+        get_metadata = Metadata(metadata_gateway)
+
+        result = get_metadata.get("icon", "some-id")
+
+        metadata_gateway.get_icon_metadata.assert_called_once_with("some-id")
+        assert result is None
+
     def test_get_return_none(self, metadata_gateway):
         metadata_gateway.get_dag_metadata = MagicMock(return_value=None)
 

--- a/usecases/metadata.py
+++ b/usecases/metadata.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional
+from typing import Callable, Optional, Union
 
 from gateways.metadata_gateway import MetadataGateway
 
@@ -8,8 +8,8 @@ class Metadata:
     def __init__(self, metadata_gateway: Optional[MetadataGateway] = None) -> None:
         self.metadata_gateway = metadata_gateway or MetadataGateway()
 
-    def get(self, type: str, id: str) -> Optional[str]:
-        metadata_methods = {
+    def get(self, type: str, id: str) -> Optional[Union[str, bytes]]:
+        metadata_methods: dict[str, Callable[[str], Optional[Union[str, bytes]]]] = {
             "dag": self.metadata_gateway.get_dag_metadata,
             "icon": self.metadata_gateway.get_icon_metadata,
         }

--- a/usecases/metadata.py
+++ b/usecases/metadata.py
@@ -11,6 +11,7 @@ class Metadata:
     def get(self, type: str, id: str) -> Optional[str]:
         metadata_methods = {
             "dag": self.metadata_gateway.get_dag_metadata,
+            "icon": self.metadata_gateway.get_icon_metadata,
         }
         method = metadata_methods.get(type, None)
         if method is None:


### PR DESCRIPTION
What
- Add a new endpoint `GET /metadata/icon?id=<id>` that proxies PNG icons stored in the metadata S3 bucket under `icons/{id}.png`.

Changes
- gateways/clients/s3_client.py: add `load_file_bytes()` to fetch raw bytes from S3.
- gateways/metadata_gateway.py: add `get_icon_metadata(id)` to read `icons/{id}.png`.
- handlers/icon_metadata_handler.py: new Lambda that returns base64 body with `isBase64Encoded: true` and `Content-Type: image/png`.
- usecases/metadata.py: register the `icon` type so it can be fetched via the usecase layer.
- serverless.yml: add IAM `s3:GetObject` permission for `icons/*`, add `get_icon_metadata_handler` function, and configure `binaryMediaTypes: ['image/png']` with a note on `Accept` header tradeoffs.
- tests: add unit tests to cover S3 bytes loading and metadata icon flow.

Why / Decisions
- API Gateway requires binary media types + correct `Accept` header to decode base64 responses to raw bytes. Browsers typically send the appropriate Accept header, but CLI clients (wget/curl) may not — they must send `Accept: image/png` or you can keep `'*/*'` in `binaryMediaTypes` (tradeoff documented in serverless.yml).
- Lambdas return base64 + `isBase64Encoded: true`; API Gateway performs decoding when request headers/content-type match the binary media types.

How to test
1) We deployed this to our test environment:
   wget --header="Accept: image/png" \
  "https://dev.explorer-service.testnet.hathor.network/metadata/icon?id=0000000073dd17b4c0f4670da70b7a2c9a07a629e38b9a47196c0fe7335f333e" -O 0000000073dd17b4c0f4670da70b7a2c9a07a629e38b9a47196c0fe7335f333e.png


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added icon metadata retrieval via GET /metadata/icon.
  * API now supports PNG/binary responses so images are served correctly.

* **Performance**
  * Endpoint caching enabled (TTL 86400s) and varies by id, origin, and Accept header.

* **Tests**
  * Added unit tests covering S3 byte retrieval, metadata gateway, and use-case integration for icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->