### PR TITLE
feat: add retry logic for 5xx gateway errors in async HTTP client

### DIFF
--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -101,6 +101,8 @@ class HathorCoreAsyncClient:
             self.log.error("hathor_core_error", path=path, error=repr(e))
             return {"error": repr(e)}
 
+        return {"error": "max retries exceeded"}
+
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None
     ) -> Dict[Any, Any]:

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -81,7 +81,9 @@ class HathorCoreAsyncClient:
                     async with session.get(url, params=params) as response:
                         if response.status > 299:
                             body = await response.text()
-                            is_retryable = response.status in self.RETRYABLE_STATUS_CODES
+                            is_retryable = (
+                                response.status in self.RETRYABLE_STATUS_CODES
+                            )
 
                             if is_retryable and attempt < self.MAX_RETRIES:
                                 await asyncio.sleep(self.RETRY_DELAY)

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -81,11 +81,9 @@ class HathorCoreAsyncClient:
                     async with session.get(url, params=params) as response:
                         if response.status > 299:
                             body = await response.text()
+                            is_retryable = response.status in self.RETRYABLE_STATUS_CODES
 
-                            if (
-                                response.status in self.RETRYABLE_STATUS_CODES
-                                and attempt < self.MAX_RETRIES
-                            ):
+                            if is_retryable and attempt < self.MAX_RETRIES:
                                 await asyncio.sleep(self.RETRY_DELAY)
                                 continue
                             self.log.warning(
@@ -94,8 +92,9 @@ class HathorCoreAsyncClient:
                                 status=response.status,
                                 body=body,
                             )
-
-                            return {"error": f"status {response.status}"}
+                            if is_retryable:
+                                return {"error": f"status {response.status}"}
+                            return await response.json(content_type=content_type)
                         return await response.json(content_type=content_type)
         except Exception as e:
             self.log.error("hathor_core_error", path=path, error=repr(e))

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -64,7 +64,8 @@ class HathorCoreAsyncClient:
         :type path: str
         :param params: params to be sent
         :type params: Optional[dict]
-        :param timeout: timeout in seconds
+        :param timeout: per-attempt timeout in seconds; total elapsed time may be higher
+            when retries are triggered
         :type timeout: Optional[float]
         """
         url = parse.urljoin(self.url, path)
@@ -72,15 +73,19 @@ class HathorCoreAsyncClient:
         if not timeout:
             timeout = self.DEFAULT_TIMEOUT
 
-        for attempt in range(self.MAX_RETRIES + 1):
-            try:
-                async with aiohttp.ClientSession(
-                    timeout=aiohttp.ClientTimeout(total=timeout)
-                ) as session:
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=timeout)
+            ) as session:
+                for attempt in range(self.MAX_RETRIES + 1):
                     async with session.get(url, params=params) as response:
-                        if response.status in self.RETRYABLE_STATUS_CODES:
+                        if response.status > 299:
                             body = await response.text()
-                            if attempt < self.MAX_RETRIES:
+
+                            if (
+                                response.status in self.RETRYABLE_STATUS_CODES
+                                and attempt < self.MAX_RETRIES
+                            ):
                                 await asyncio.sleep(self.RETRY_DELAY)
                                 continue
                             self.log.warning(
@@ -89,18 +94,12 @@ class HathorCoreAsyncClient:
                                 status=response.status,
                                 body=body,
                             )
+
                             return {"error": f"status {response.status}"}
-                        if response.status > 299:
-                            self.log.warning(
-                                "hathor_core_error",
-                                path=path,
-                                status=response.status,
-                                body=await response.text(),
-                            )
                         return await response.json(content_type=content_type)
-            except Exception as e:
-                self.log.error("hathor_core_error", path=path, error=repr(e))
-                return {"error": repr(e)}
+        except Exception as e:
+            self.log.error("hathor_core_error", path=path, error=repr(e))
+            return {"error": repr(e)}
 
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict, Optional
 from urllib import parse
@@ -37,6 +38,9 @@ HEALTH_ENDPOINT = "/v1a/health"
 
 class HathorCoreAsyncClient:
     DEFAULT_TIMEOUT = 60  # seconds
+    MAX_RETRIES = 2
+    RETRY_DELAY = 1.0  # seconds between retries
+    RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
 
     def __init__(self, url: Optional[str] = None) -> None:
         """Client to make async requests
@@ -68,22 +72,35 @@ class HathorCoreAsyncClient:
         if not timeout:
             timeout = self.DEFAULT_TIMEOUT
 
-        try:
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=timeout)
-            ) as session:
-                async with session.get(url, params=params) as response:
-                    if response.status > 299:
-                        self.log.warning(
-                            "hathor_core_error",
-                            path=path,
-                            status=response.status,
-                            body=await response.text(),
-                        )
-                    return await response.json(content_type=content_type)
-        except Exception as e:
-            self.log.error("hathor_core_error", path=path, error=repr(e))
-            return {"error": repr(e)}
+        for attempt in range(self.MAX_RETRIES + 1):
+            try:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(total=timeout)
+                ) as session:
+                    async with session.get(url, params=params) as response:
+                        if response.status in self.RETRYABLE_STATUS_CODES:
+                            body = await response.text()
+                            if attempt < self.MAX_RETRIES:
+                                await asyncio.sleep(self.RETRY_DELAY)
+                                continue
+                            self.log.warning(
+                                "hathor_core_error",
+                                path=path,
+                                status=response.status,
+                                body=body,
+                            )
+                            return {"error": f"status {response.status}"}
+                        if response.status > 299:
+                            self.log.warning(
+                                "hathor_core_error",
+                                path=path,
+                                status=response.status,
+                                body=await response.text(),
+                            )
+                        return await response.json(content_type=content_type)
+            except Exception as e:
+                self.log.error("hathor_core_error", path=path, error=repr(e))
+                return {"error": repr(e)}
 
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -79,30 +79,49 @@ class HathorCoreAsyncClient:
             ) as session:
                 for attempt in range(self.MAX_RETRIES + 1):
                     async with session.get(url, params=params) as response:
-                        if response.status > 299:
-                            body = await response.text()
-                            is_retryable = (
-                                response.status in self.RETRYABLE_STATUS_CODES
-                            )
-
-                            if is_retryable and attempt < self.MAX_RETRIES:
-                                await asyncio.sleep(self.RETRY_DELAY)
-                                continue
-                            self.log.warning(
-                                "hathor_core_error",
-                                path=path,
-                                status=response.status,
-                                body=body,
-                            )
-                            if is_retryable:
-                                return {"error": f"status {response.status}"}
+                        if response.status <= 299:
                             return await response.json(content_type=content_type)
-                        return await response.json(content_type=content_type)
+
+                        body = await response.text()
+                        is_retryable = response.status in self.RETRYABLE_STATUS_CODES
+                        if is_retryable and attempt < self.MAX_RETRIES:
+                            await asyncio.sleep(self.RETRY_DELAY)
+                            continue
+
+                        self.log.warning(
+                            "hathor_core_error",
+                            path=path,
+                            status=response.status,
+                            body=body,
+                        )
+                        return self._decode_error_body(response.status, body)
         except Exception as e:
             self.log.error("hathor_core_error", path=path, error=repr(e))
             return {"error": repr(e)}
 
         return {"error": "max retries exceeded"}
+
+    @staticmethod
+    def _decode_error_body(status: int, body: str) -> Dict[Any, Any]:
+        """Build the return value for an error response (status > 299).
+
+        Whenever the body is valid JSON we return it as-is, so callers keep
+        access to the server-provided error details. Some upstream errors
+        (e.g. GCP load balancer 5xx) come back as plain text/HTML instead, so
+        in that case we return the status together with the raw body, which
+        usually carries enough context to understand what went wrong.
+
+        :param status: HTTP status code of the response
+        :param body: response body already read as text
+        """
+        try:
+            decoded = json.loads(body)
+        except ValueError:
+            return {"error": f"status {status}", "body": body}
+
+        if isinstance(decoded, dict):
+            return decoded
+        return {"error": f"status {status}", "body": decoded}
 
     async def post(
         self, path: str, body: Optional[dict] = None, timeout: Optional[float] = None

--- a/gateways/clients/hathor_core_client.py
+++ b/gateways/clients/hathor_core_client.py
@@ -57,6 +57,7 @@ class HathorCoreAsyncClient:
         params: Optional[dict] = None,
         timeout: Optional[float] = None,
         content_type: Optional[str] = "application/json",
+        retry: bool = True,
     ) -> Dict[Any, Any]:
         """Make a get request async
 
@@ -67,24 +68,31 @@ class HathorCoreAsyncClient:
         :param timeout: per-attempt timeout in seconds; total elapsed time may be higher
             when retries are triggered
         :type timeout: Optional[float]
+        :param retry: whether to retry on transient gateway errors (502/503/504).
+            Disable it for endpoints where such a status is a legitimate answer
+            rather than a transient gateway failure (e.g. the health endpoint,
+            which returns 503 when the fullnode is unhealthy).
+        :type retry: bool
         """
         url = parse.urljoin(self.url, path)
 
         if not timeout:
             timeout = self.DEFAULT_TIMEOUT
 
+        max_retries = self.MAX_RETRIES if retry else 0
+
         try:
             async with aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=timeout)
             ) as session:
-                for attempt in range(self.MAX_RETRIES + 1):
+                for attempt in range(max_retries + 1):
                     async with session.get(url, params=params) as response:
                         if response.status <= 299:
                             return await response.json(content_type=content_type)
 
                         body = await response.text()
                         is_retryable = response.status in self.RETRYABLE_STATUS_CODES
-                        if is_retryable and attempt < self.MAX_RETRIES:
+                        if is_retryable and attempt < max_retries:
                             await asyncio.sleep(self.RETRY_DELAY)
                             continue
 

--- a/gateways/healthcheck_gateway.py
+++ b/gateways/healthcheck_gateway.py
@@ -42,6 +42,11 @@ class HealthcheckGateway:
             HEALTH_ENDPOINT,
             timeout=HEALTHCHECK_CLIENT_TIMEOUT_IN_SECONDS,
             content_type=None,
+            # The health endpoint returns 503 when the fullnode is unhealthy, which
+            # is a legitimate answer (the body still carries the 'status') rather than
+            # a transient gateway error. Retrying it would only waste the tight
+            # healthcheck timeout budget, so we opt out of retries here.
+            retry=False,
         )
 
     def ping_redis(self) -> bool:

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -1,10 +1,114 @@
 import json
-from unittest.mock import patch
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import requests
 from pytest import raises
 
-from gateways.clients.hathor_core_client import HathorCoreClient
+from gateways.clients.hathor_core_client import HathorCoreAsyncClient, HathorCoreClient
+
+
+def _make_response(status: int, json_data=None, text_data: str = "") -> MagicMock:
+    """Build a minimal aiohttp response mock."""
+    mock = MagicMock()
+    mock.status = status
+    mock.text = AsyncMock(return_value=text_data)
+    mock.json = AsyncMock(return_value=json_data)
+    return mock
+
+
+def _as_ctx(response_mock: MagicMock) -> MagicMock:
+    """Wrap a response mock so it can be used as an async context manager."""
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=response_mock)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_success(self, mock_sleep, mock_get):
+        """200 response: returns parsed JSON, no retries."""
+        data = {"success": True}
+        mock_get.return_value = _as_ctx(_make_response(200, json_data=data))
+
+        client = HathorCoreAsyncClient("http://test.node")
+        result = await client.get("/v1a/status")
+
+        assert result == data
+        mock_sleep.assert_not_called()
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_retries_on_502_then_succeeds(self, mock_sleep, mock_get):
+        """502 on first attempt, 200 on retry: no warning logged, returns data."""
+        data = {"id": "abc"}
+        mock_get.side_effect = [
+            _as_ctx(_make_response(502, text_data="<html>502 Bad Gateway</html>")),
+            _as_ctx(_make_response(200, json_data=data)),
+        ]
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/status")
+
+        assert result == data
+        mock_log.warning.assert_not_called()
+        mock_sleep.assert_called_once_with(HathorCoreAsyncClient.RETRY_DELAY)
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_logs_warning_after_all_retries_exhausted(self, mock_sleep, mock_get):
+        """All attempts return 502: exactly one warning logged, returns error dict."""
+        retry_body = "<html>502 Bad Gateway</html>"
+        total_attempts = HathorCoreAsyncClient.MAX_RETRIES + 1
+        mock_get.side_effect = [
+            _as_ctx(_make_response(502, text_data=retry_body))
+            for _ in range(total_attempts)
+        ]
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/status")
+
+        assert "error" in result
+        mock_log.warning.assert_called_once_with(
+            "hathor_core_error",
+            path="/v1a/status",
+            status=502,
+            body=retry_body,
+        )
+        assert mock_sleep.call_count == HathorCoreAsyncClient.MAX_RETRIES
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_no_retry_on_4xx(self, mock_sleep, mock_get):
+        """4xx error: logged immediately without any retry."""
+        mock_get.return_value = _as_ctx(
+            _make_response(404, text_data="Not Found", json_data=None)
+        )
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            await client.get("/v1a/missing")
+
+        mock_sleep.assert_not_called()
+        mock_log.warning.assert_called_once()
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_no_retry_on_exception(self, mock_sleep, mock_get):
+        """Network exception: logged as error immediately, no retry."""
+        mock_get.side_effect = Exception("connection refused")
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/status")
+
+        assert "error" in result
+        mock_log.error.assert_called_once()
+        mock_sleep.assert_not_called()
 
 
 class TestHathorCoreClient:

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import requests
@@ -9,7 +10,9 @@ from pytest import raises
 from gateways.clients.hathor_core_client import HathorCoreAsyncClient, HathorCoreClient
 
 
-def _make_response(status: int, json_data=None, text_data: str = "") -> MagicMock:
+def _make_response(
+    status: int, json_data: Any = None, text_data: str = ""
+) -> MagicMock:
     """Build a minimal aiohttp response mock."""
     mock = MagicMock()
     mock.status = status

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import requests
+from aiohttp import ContentTypeError, RequestInfo
 from pytest import raises
 
 from gateways.clients.hathor_core_client import HathorCoreAsyncClient, HathorCoreClient
@@ -23,6 +24,12 @@ def _as_ctx(response_mock: MagicMock) -> MagicMock:
     cm.__aenter__ = AsyncMock(return_value=response_mock)
     cm.__aexit__ = AsyncMock(return_value=None)
     return cm
+
+
+def _make_non_json_error() -> ContentTypeError:
+    request_info = MagicMock(spec=RequestInfo)
+    request_info.real_url = "http://test.node/v1a/status"
+    return ContentTypeError(request_info=request_info, history=())
 
 
 class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
@@ -57,9 +64,37 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
         mock_log.warning.assert_not_called()
         mock_sleep.assert_called_once_with(HathorCoreAsyncClient.RETRY_DELAY)
 
+    @patch("gateways.clients.hathor_core_client.aiohttp.ClientSession")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_reuses_single_session_across_retries(
+        self, mock_sleep, mock_client_session
+    ):
+        """Retries reuse one aiohttp session while keeping per-attempt timeouts."""
+        data = {"id": "abc"}
+        session = MagicMock()
+        session.get.side_effect = [
+            _as_ctx(_make_response(502, text_data="<html>502 Bad Gateway</html>")),
+            _as_ctx(_make_response(200, json_data=data)),
+        ]
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_client_session.return_value = session_cm
+
+        client = HathorCoreAsyncClient("http://test.node")
+        result = await client.get("/v1a/status", timeout=7)
+
+        assert result == data
+        mock_client_session.assert_called_once()
+        assert mock_client_session.call_args.kwargs["timeout"].total == 7
+        assert session.get.call_count == 2
+        mock_sleep.assert_called_once_with(HathorCoreAsyncClient.RETRY_DELAY)
+
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
-    async def test_get_logs_warning_after_all_retries_exhausted(self, mock_sleep, mock_get):
+    async def test_get_logs_warning_after_all_retries_exhausted(
+        self, mock_sleep, mock_get
+    ):
         """All attempts return 502: exactly one warning logged, returns error dict."""
         retry_body = "<html>502 Bad Gateway</html>"
         total_attempts = HathorCoreAsyncClient.MAX_RETRIES + 1
@@ -95,6 +130,60 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
 
         mock_sleep.assert_not_called()
         mock_log.warning.assert_called_once()
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_4xx_non_json_body_returns_error_without_parsing_json(
+        self, mock_sleep, mock_get
+    ):
+        """4xx error bodies must not be parsed as JSON."""
+        response = _make_response(404, text_data="Not Found")
+        response.json = AsyncMock(side_effect=_make_non_json_error())
+        mock_get.return_value = _as_ctx(response)
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/missing")
+
+        assert result == {"error": "status 404"}
+        response.json.assert_not_called()
+        mock_sleep.assert_not_called()
+        mock_log.warning.assert_called_once_with(
+            "hathor_core_error",
+            path="/v1a/missing",
+            status=404,
+            body="Not Found",
+        )
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_5xx_non_json_body_returns_error_after_retries(
+        self, mock_sleep, mock_get
+    ):
+        """Retryable 5xx error bodies must not be parsed as JSON after retries."""
+        retry_body = "<html>502 Bad Gateway</html>"
+        total_attempts = HathorCoreAsyncClient.MAX_RETRIES + 1
+        responses = []
+        for _ in range(total_attempts):
+            response = _make_response(502, text_data=retry_body)
+            response.json = AsyncMock(side_effect=_make_non_json_error())
+            responses.append(_as_ctx(response))
+        mock_get.side_effect = responses
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/status")
+
+        assert result == {"error": "status 502"}
+        for response_ctx in responses:
+            response_ctx.__aenter__.return_value.json.assert_not_called()
+        assert mock_sleep.call_count == HathorCoreAsyncClient.MAX_RETRIES
+        mock_log.warning.assert_called_once_with(
+            "hathor_core_error",
+            path="/v1a/status",
+            status=502,
+            body=retry_body,
+        )
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -136,26 +136,32 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
-    async def test_get_4xx_non_json_body_returns_error_without_parsing_json(
+    async def test_get_4xx_non_json_body_returns_parsing_error(
         self, mock_sleep, mock_get
     ):
-        """4xx error bodies must not be parsed as JSON."""
+        """4xx non-JSON error bodies still go through response.json()."""
         response = _make_response(404, text_data="Not Found")
-        response.json = AsyncMock(side_effect=_make_non_json_error())
+        parsing_error = _make_non_json_error()
+        response.json = AsyncMock(side_effect=parsing_error)
         mock_get.return_value = _as_ctx(response)
 
         client = HathorCoreAsyncClient("http://test.node")
         with patch.object(client, "log") as mock_log:
             result = await client.get("/v1a/missing")
 
-        assert result == {"error": "status 404"}
-        response.json.assert_not_called()
+        assert result == {"error": repr(parsing_error)}
+        response.json.assert_called_once_with(content_type="application/json")
         mock_sleep.assert_not_called()
         mock_log.warning.assert_called_once_with(
             "hathor_core_error",
             path="/v1a/missing",
             status=404,
             body="Not Found",
+        )
+        mock_log.error.assert_called_once_with(
+            "hathor_core_error",
+            path="/v1a/missing",
+            error=repr(parsing_error),
         )
 
     @patch("aiohttp.ClientSession.get")

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -211,6 +211,43 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_retry_false_skips_retries_on_5xx(self, mock_sleep, mock_get):
+        """retry=False returns the first 5xx response without retrying."""
+        retry_body = "<html>503 Service Unavailable</html>"
+        mock_get.return_value = _as_ctx(_make_response(503, text_data=retry_body))
+
+        client = HathorCoreAsyncClient("http://test.node")
+        with patch.object(client, "log") as mock_log:
+            result = await client.get("/v1a/health", retry=False)
+
+        assert result == {"error": "status 503", "body": retry_body}
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+        mock_log.warning.assert_called_once_with(
+            "hathor_core_error",
+            path="/v1a/health",
+            status=503,
+            body=retry_body,
+        )
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_retry_false_keeps_json_body_on_5xx(self, mock_sleep, mock_get):
+        """retry=False still returns the server-provided JSON body as-is."""
+        health_body = {"status": "fail", "checks": {}}
+        mock_get.return_value = _as_ctx(
+            _make_response(503, text_data=json.dumps(health_body))
+        )
+
+        client = HathorCoreAsyncClient("http://test.node")
+        result = await client.get("/v1a/health", retry=False)
+
+        assert result == health_body
+        assert mock_get.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
     async def test_get_no_retry_on_exception(self, mock_sleep, mock_get):
         """Network exception: logged as error immediately, no retry."""
         mock_get.side_effect = Exception("connection refused")

--- a/tests/unit/gateways/clients/test_hathor_core_client.py
+++ b/tests/unit/gateways/clients/test_hathor_core_client.py
@@ -122,35 +122,37 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
     async def test_get_no_retry_on_4xx(self, mock_sleep, mock_get):
-        """4xx error: logged immediately without any retry."""
+        """4xx error: logged immediately without any retry, JSON body kept."""
+        error_body = {"success": False, "message": "not found"}
         mock_get.return_value = _as_ctx(
-            _make_response(404, text_data="Not Found", json_data=None)
+            _make_response(404, text_data=json.dumps(error_body))
         )
 
         client = HathorCoreAsyncClient("http://test.node")
         with patch.object(client, "log") as mock_log:
-            await client.get("/v1a/missing")
+            result = await client.get("/v1a/missing")
 
+        assert result == error_body
         mock_sleep.assert_not_called()
         mock_log.warning.assert_called_once()
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
-    async def test_get_4xx_non_json_body_returns_parsing_error(
+    async def test_get_4xx_non_json_body_returns_status_and_body(
         self, mock_sleep, mock_get
     ):
-        """4xx non-JSON error bodies still go through response.json()."""
+        """4xx non-JSON error bodies are returned as status + raw body."""
         response = _make_response(404, text_data="Not Found")
-        parsing_error = _make_non_json_error()
-        response.json = AsyncMock(side_effect=parsing_error)
+        # json() must never be called: we decode the text body ourselves.
+        response.json = AsyncMock(side_effect=_make_non_json_error())
         mock_get.return_value = _as_ctx(response)
 
         client = HathorCoreAsyncClient("http://test.node")
         with patch.object(client, "log") as mock_log:
             result = await client.get("/v1a/missing")
 
-        assert result == {"error": repr(parsing_error)}
-        response.json.assert_called_once_with(content_type="application/json")
+        assert result == {"error": "status 404", "body": "Not Found"}
+        response.json.assert_not_called()
         mock_sleep.assert_not_called()
         mock_log.warning.assert_called_once_with(
             "hathor_core_error",
@@ -158,18 +160,14 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
             status=404,
             body="Not Found",
         )
-        mock_log.error.assert_called_once_with(
-            "hathor_core_error",
-            path="/v1a/missing",
-            error=repr(parsing_error),
-        )
+        mock_log.error.assert_not_called()
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
-    async def test_get_5xx_non_json_body_returns_error_after_retries(
+    async def test_get_5xx_non_json_body_returns_status_and_body_after_retries(
         self, mock_sleep, mock_get
     ):
-        """Retryable 5xx error bodies must not be parsed as JSON after retries."""
+        """Retryable 5xx non-JSON bodies are returned as status + raw body."""
         retry_body = "<html>502 Bad Gateway</html>"
         total_attempts = HathorCoreAsyncClient.MAX_RETRIES + 1
         responses = []
@@ -183,7 +181,7 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
         with patch.object(client, "log") as mock_log:
             result = await client.get("/v1a/status")
 
-        assert result == {"error": "status 502"}
+        assert result == {"error": "status 502", "body": retry_body}
         for response_ctx in responses:
             response_ctx.__aenter__.return_value.json.assert_not_called()
         assert mock_sleep.call_count == HathorCoreAsyncClient.MAX_RETRIES
@@ -193,6 +191,23 @@ class TestHathorCoreAsyncClientGet(unittest.IsolatedAsyncioTestCase):
             status=502,
             body=retry_body,
         )
+
+    @patch("aiohttp.ClientSession.get")
+    @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)
+    async def test_get_5xx_json_body_returned_after_retries(self, mock_sleep, mock_get):
+        """Retryable 5xx with a JSON body keeps the server-provided payload."""
+        error_body = {"error": "upstream exploded"}
+        total_attempts = HathorCoreAsyncClient.MAX_RETRIES + 1
+        mock_get.side_effect = [
+            _as_ctx(_make_response(503, text_data=json.dumps(error_body)))
+            for _ in range(total_attempts)
+        ]
+
+        client = HathorCoreAsyncClient("http://test.node")
+        result = await client.get("/v1a/status")
+
+        assert result == error_body
+        assert mock_sleep.call_count == HathorCoreAsyncClient.MAX_RETRIES
 
     @patch("aiohttp.ClientSession.get")
     @patch("gateways.clients.hathor_core_client.asyncio.sleep", new_callable=AsyncMock)

--- a/tests/unit/gateways/test_healthcheck_gateway.py
+++ b/tests/unit/gateways/test_healthcheck_gateway.py
@@ -26,7 +26,7 @@ class TestHealthcheckGateway(unittest.IsolatedAsyncioTestCase):
         result = await self.healthcheck_gateway.get_hathor_core_health()
         self.assertEqual(result, {"status": "pass"})
         self.hathor_core_async_client.get.assert_called_once_with(
-            "/v1a/health", timeout=5, content_type=None
+            "/v1a/health", timeout=5, content_type=None, retry=False
         )
 
     def test_ping_redis(self):


### PR DESCRIPTION
## Problem

When a fullnode is temporarily unreachable (e.g. nginx returns `502 Bad Gateway`), the daemon was generating **three log entries per node per 1-second polling cycle**, triggering spurious alerts:

```
1. WARNING  hathor_core_error      {client: async, path: /v1a/status, status: 502, body: <html>...}
2. ERROR    hathor_core_error      {client: async, path: /v1a/status, error: ContentTypeError(...)}
3. WARNING  collect_status_error   {error: ContentTypeError(...)}
```

### Root cause

`HathorCoreAsyncClient.get()` had no retry mechanism, and `response.json()` was called unconditionally:

1. Any non-2xx status code immediately logged a `WARNING` with the raw body.
2. `response.json()` was then called on a 502 response whose body is nginx HTML — this raised a `ContentTypeError`, caught by the `except` branch, which logged an `ERROR` and returned `{"error": repr(exc)}` (the original body lost).
3. `_send()` in `CollectNodesStatuses` saw the `"error"` key in the returned dict and logged a third `WARNING`.

## Solution

### 1. Retry transient gateway errors

`HathorCoreAsyncClient.get()` now retries retryable gateway errors (`502`, `503`, `504`):

- **`MAX_RETRIES = 2`** — up to 2 retries before giving up
- **`RETRY_DELAY = 1.0s`** — wait 1 second between attempts
- **`RETRYABLE_STATUS_CODES = {502, 503, 504}`** — only gateway-level transient errors are retried

All attempts share a single `aiohttp.ClientSession`. On a retryable status the body is read (consuming the connection cleanly) and the loop either sleeps + retries or, once retries are exhausted, logs a single `WARNING` and returns the decoded body (see below). Non-retryable 4xx errors are never retried. The `get()` docstring now also clarifies that `timeout` is **per-attempt**, so total elapsed time may exceed it when retries happen.

### 2. Decode error bodies instead of unconditionally calling `response.json()`

For any error response (`status > 299`), `_decode_error_body` returns:

- the server-provided **JSON body as-is** when the body is valid JSON (callers keep the full error details — this matches `main`'s behavior for JSON error bodies);
- `{"error": "status X", "body": <raw body>}` when the body is **not** JSON (e.g. GCP load balancer / nginx 5xx that come back as HTML/plain text).

This is the key fix versus `main`: a non-JSON error body no longer reaches `response.json()`, so it no longer raises a `ContentTypeError` (eliminating the spurious `ERROR` log) and the raw error text is preserved instead of being replaced by `repr(exc)`. Successful (`<= 299`) responses are unchanged: the JSON body is returned verbatim.

### 3. Retry opt-out for the health endpoint

Because a `503` from `/v1a/health` is a *legitimate answer* (unhealthy fullnode) rather than a transient gateway failure, retrying it would only burn the tight healthcheck timeout budget (5s client / 6s lambda). `get()` takes a `retry` flag (default `True`) and `HealthcheckGateway` passes `retry=False`, so genuine gateway errors are still retried everywhere else.

### Outcome (per failing poll cycle, vs `main`)

| Scenario | `main` | This PR |
|---|---|---|
| Transient 502 (recovers within retries) | 1 WARNING + 1 ERROR + 1 WARNING = 3 | **0** |
| Persistent 502 (all retries fail) | 1 WARNING + 1 ERROR + 1 WARNING = 3 | **2** — `hathor_core_error` WARNING + `collect_status_error` WARNING; the spurious `ERROR` is gone |

## Why this fits the two current callers

This client is consumed in only two places, and neither relies on the HTTP status code to detect errors — which matches hathor-core's convention of **frequently returning errors with HTTP 200 and signalling them in the body** (many resources `return {'success': False, ...}` without ever setting a response code). Error detection here is intentionally body-based, not status-based.

| Caller | Endpoint | hathor-core behavior | How the caller reads the result |
|---|---|---|---|
| `CollectNodesStatuses` (`usecases/collect_nodes_statuses.py`) | `/v1a/status` | `StatusResource.render_GET` **always returns HTTP 200** with the status dump — no error branch, never sets a response code. The only failures observable here are transport-level (timeout / connection refused) → `{"error": repr(e)}`, plus upstream gateway 5xx from nginx/LB. | Checks `if "error" in data`, otherwise parses the body with `Node.from_status_dict`. Since the endpoint itself never returns an error status, it only reaches `_decode_error_body` for upstream gateway errors (non-JSON → `{"error": ..., "body": ...}`, still caught by the `"error"` check). |
| `GetHealthcheck` (`usecases/get_healthcheck.py` via `HealthcheckGateway`) | `/v1a/health` | `HealthcheckResource` returns **200 when healthy and 503 when unhealthy**, but the verdict is always in the body (`status: pass/fail`). It also accepts `strict_status_code=1` to force 200 even when failing. | Reads `health_response["status"]` for the `pass`/`warn`/`fail` nuance, so it needs the 503 body returned as-is — which `_decode_error_body` does (the body is a JSON object). Retries are disabled here so the legitimate 503 is returned immediately. |

## Changes

- `gateways/clients/hathor_core_client.py` — retry loop in `HathorCoreAsyncClient.get()`; `MAX_RETRIES` / `RETRY_DELAY` / `RETRYABLE_STATUS_CODES` constants; `_decode_error_body`; `retry` opt-out flag; per-attempt `timeout` docstring
- `gateways/healthcheck_gateway.py` — pass `retry=False` for the health endpoint
- `tests/unit/gateways/clients/test_hathor_core_client.py` — new `TestHathorCoreAsyncClientGet` covering success, retry-then-success, single session reuse, retry exhaustion, non-retryable 4xx, JSON/non-JSON error bodies, the `retry=False` opt-out, and network exceptions
- `tests/unit/gateways/test_healthcheck_gateway.py` — assert `retry=False` is passed for the health call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transient retry support for gateway requests via an opt-in retry mode, with per-attempt timeout handling.
* **Bug Fixes**
  * Healthcheck requests now explicitly avoid retries to preserve the healthcheck timeout budget.
  * Improved consistent error normalization for non-JSON/JSON failure responses, including behavior when retries are exhausted.
* **Tests**
  * Expanded unit coverage for retry success, retry exhaustion, non-retryable 4xx behavior, non-JSON vs JSON error handling, and network exception scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
