### PR TITLE
chore: adopt new release workflow with release-candidate and release branches

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-### Acceptance Criteria
-- Include here all things that this PR should solve
+Please go to the `Preview` tab and select the appropriate Pull Request template:
 
-
-### Security Checklist
-- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
+* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are merging a feature branch into `main`
+* [Release Candidate](?expand=1&template=release_candidate_pr_template.md) - Use this PR template when you are merging `main` into `release-candidate`
+* [Release](?expand=1&template=release_pr_template.md) - Use this PR template when you are merging `release-candidate` into `release`

--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
@@ -1,0 +1,12 @@
+### Motivation
+
+What was the motivation for the changes in this PR?
+
+### Acceptance Criteria
+
+- Include here all things that this PR should solve
+
+### Checklist
+
+- [ ] If you are requesting a merge into `main`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
+- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
@@ -1,0 +1,8 @@
+# Changes
+
+Link here all the PRs that are included in this release candidate
+
+# Checklist
+
+- [ ] I've read and followed the release candidate process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/hathor-explorer-service.md#release-candidate
+- [ ] I confirm this release candidate only includes production-ready changes

--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -1,0 +1,12 @@
+# Changes
+
+Link here all the PRs that are included in this release
+
+# Release-candidates
+
+Link here the release-candidates that were deployed as part of this release
+
+# Checklist
+
+- [ ] I've read and followed the release process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/hathor-explorer-service.md#stable-release
+- [ ] The QA process was run successfully during the tests of the corresponding release-candidate(s)

--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -9,4 +9,4 @@ Link here the release-candidates that were deployed as part of this release
 # Checklist
 
 - [ ] I've read and followed the release process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/hathor-explorer-service.md#stable-release
-- [ ] The QA process was run successfully during the tests of the corresponding release-candidate(s)
+- [ ] All CI checks on the `release-candidate` branch are green

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -14,8 +14,8 @@ runs:
       run: |
         pip -q --no-input install poetry poetry-plugin-export
     - name: Set up Python
-      # https://github.com/actions/setup-python/releases/tag/v5.4.0
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+      # https://github.com/actions/setup-python/releases/tag/v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: ${{ inputs.python_version }}
         cache: 'poetry'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main", "release-candidate", "release" ]
   pull_request:
   schedule:
     - cron: "16 8 * * 6"
@@ -23,18 +23,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,15 +26,18 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        # https://github.com/github/codeql-action/releases/tag/v4.35.5
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        # https://github.com/github/codeql-action/releases/tag/v4.35.5
+        uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        # https://github.com/github/codeql-action/releases/tag/v4.35.5
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -121,17 +121,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Configure AWS Credentials
-        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v4.0.2
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v6.1.0
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           aws-region: ${{ inputs.aws_region }}
           role-to-assume: ${{ inputs.aws_iam_role }}
       - name: Get Secrets from AWS
-        # https://github.com/aws-actions/aws-secretsmanager-get-secrets/releases/tag/v2.0.6
-        uses: aws-actions/aws-secretsmanager-get-secrets@4e95aaf6ba8028772f5384971d4fedccfaab8621
+        # https://github.com/aws-actions/aws-secretsmanager-get-secrets/releases/tag/v3.0.1
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53
         with:
           # The comma before the secret id is to avoid the addition of a prefix to the env vars.
           # See: https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_github.html#retrieving-secrets_github_alias
@@ -140,8 +141,8 @@ jobs:
           parse-json-secrets: true
       # This step recovers the artifact that is generated in the `deploy.yml` workflow
       - name: Download node modules
-        # https://github.com/actions/download-artifact/releases/tag/v4.1.8
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        # https://github.com/actions/download-artifact/releases/tag/v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: node_modules
       - name: Unpack node modules

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -106,6 +106,15 @@ on:
         required: false
         default: 'hathor-explorer-service'
         type: string
+      slack_notify:
+        description: 'Send a Slack notification to #deploys on completion'
+        required: false
+        default: false
+        type: boolean
+
+    secrets:
+      SLACK_WEBHOOK:
+        required: false
 
 jobs:
   deploy:
@@ -174,3 +183,17 @@ jobs:
           rm /home/runner/.docker/config.json
         env:
           AWS_ECR_ACCOUNT_ID: ${{ inputs.aws_ecr_account_id }}
+
+      - name: Slack Notification
+        if: ${{ inputs.slack_notify }}
+        # https://github.com/rtCamp/action-slack-notify/releases/tag/v2.3.3
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+        env:
+          SLACK_CHANNEL: deploys
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: 'HathorExplorerService - ${{ inputs.serverless_stage }} deployed :rocket:'
+          SLACK_MESSAGE: 'Make sure the daemon is correctly deployed by checking if a new commit by fluxcdbot was made in: https://github.com/HathorNetwork/ops-tools/commits/master'
+          SLACK_USERNAME: HathorSlack
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: actions url

--- a/.github/workflows/deploy-reusable.yml
+++ b/.github/workflows/deploy-reusable.yml
@@ -186,14 +186,14 @@ jobs:
           AWS_ECR_ACCOUNT_ID: ${{ inputs.aws_ecr_account_id }}
 
       - name: Slack Notification
-        if: ${{ inputs.slack_notify }}
+        if: ${{ inputs.slack_notify && always() }}
         # https://github.com/rtCamp/action-slack-notify/releases/tag/v2.3.3
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         env:
           SLACK_CHANNEL: deploys
           SLACK_COLOR: ${{ job.status }}
-          SLACK_TITLE: 'HathorExplorerService - ${{ inputs.serverless_stage }} deployed :rocket:'
-          SLACK_MESSAGE: 'Make sure the daemon is correctly deployed by checking if a new commit by fluxcdbot was made in: https://github.com/HathorNetwork/ops-tools/commits/master'
+          SLACK_TITLE: "${{ job.status == 'success' && format('HathorExplorerService - {0} deployed :rocket:', inputs.serverless_stage) || format('HathorExplorerService - {0} deployment failed :x:', inputs.serverless_stage) }}"
+          SLACK_MESSAGE: "${{ job.status == 'success' && 'Make sure the daemon is correctly deployed by checking if a new commit by fluxcdbot was made in: https://github.com/HathorNetwork/ops-tools/commits/master' || 'Check the GitHub Actions logs for the failed deployment step before retrying.' }}"
           SLACK_USERNAME: HathorSlack
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_FOOTER: ''

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,16 +32,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-        # https://github.com/actions/checkout/releases/tag/v4.2.2
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Node.js 20.x
-        # https://github.com/actions/setup-node/releases/tag/v4.2.0
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+        # https://github.com/actions/setup-node/releases/tag/v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 20.x
       - name: Cache node modules
-        # https://github.com/actions/cache/releases/tag/v3.4.3
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f
+        # https://github.com/actions/cache/releases/tag/v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         env:
           cache-name: cache-node-modules
         with:
@@ -59,8 +59,8 @@ jobs:
         run: |
           tar -cvf node_modules.tar ./node_modules
       - name: Upload node modules
-        # https://github.com/actions/upload-artifact/releases/tag/v4.3.4
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
+        # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: node_modules
           path: node_modules.tar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,8 @@ jobs:
       healthcheck_redis_enabled: true
       serverless_deploy_prefix: explorer-svc
       slack_notify: true
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-ekvilibro-testnet:
     needs: [init, dependencies]
@@ -156,7 +157,8 @@ jobs:
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
       slack_notify: true
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-ekvilibro-mainnet:
     needs: [init, dependencies]
@@ -186,7 +188,8 @@ jobs:
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
       slack_notify: true
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-mainnet:
     needs: [init, dependencies]
@@ -217,7 +220,8 @@ jobs:
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
       slack_notify: true
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   deploy-testnet-playground:
     needs: [init, dependencies]
@@ -249,4 +253,5 @@ jobs:
       healthcheck_redis_enabled: true
       serverless_deploy_prefix: explorer-svc
       slack_notify: true
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     tags: ['v*.*.*']
 
 jobs:
@@ -15,13 +15,13 @@ jobs:
       - name: Set environment
         id: setenv
         run: |
-          if [[ "${{github.ref}}" == refs/tags/v* ]]; then
+          if [[ "${{github.ref}}" == refs/tags/v*-rc* ]]; then
+            echo "Setting testnet environment (RC tag)"
+            echo "environment=testnet" >> $GITHUB_OUTPUT
+          elif [[ "${{github.ref}}" == refs/tags/v* ]]; then
             echo "Setting mainnet environment"
             echo "environment=mainnet" >> $GITHUB_OUTPUT
-          elif [[ "${{github.base_ref}}" == "main" || "${{github.ref}}" == "refs/heads/main" ]]; then
-            echo "Setting testnet environment"
-            echo "environment=testnet" >> $GITHUB_OUTPUT
-          elif [[ "${{github.base_ref}}" == "dev" || "${{github.ref}}" == "refs/heads/dev" ]]; then
+          elif [[ "${{github.ref}}" == "refs/heads/main" ]]; then
             echo "Setting dev environment"
             echo "environment=dev" >> $GITHUB_OUTPUT
           fi
@@ -77,7 +77,7 @@ jobs:
       aws_iam_role: arn:aws:iam::769498303037:role/ExplorerServiceGitHubActionsRole
       aws_secret_arn: arn:aws:secretsmanager:eu-central-1:769498303037:secret:ExplorerService/dev-0ikehC
       serverless_stage: dev
-      docker_image_tag: dev-${{ github.sha }}-${{ needs.init.outputs.timestamp }}
+      docker_image_tag: main-${{ github.sha }}-${{ needs.init.outputs.timestamp }}
       # XXX: Some env vars come from the secret https://eu-central-1.console.aws.amazon.com/secretsmanager/secret?name=ExplorerService%2Fdev&region=eu-central-1
       api_port: 3001
       hathor_core_url: https://node.explorer.testnet.hathor.network
@@ -124,6 +124,8 @@ jobs:
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
       serverless_deploy_prefix: explorer-svc
+      slack_notify: true
+    secrets: inherit
 
   deploy-ekvilibro-testnet:
     needs: [init, dependencies]
@@ -153,6 +155,8 @@ jobs:
       healthcheck_wallet_service_db_enabled: true
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
+      slack_notify: true
+    secrets: inherit
 
   deploy-ekvilibro-mainnet:
     needs: [init, dependencies]
@@ -181,6 +185,8 @@ jobs:
       healthcheck_wallet_service_db_enabled: true
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
+      slack_notify: true
+    secrets: inherit
 
   deploy-mainnet:
     needs: [init, dependencies]
@@ -210,6 +216,8 @@ jobs:
       healthcheck_wallet_service_db_enabled: true
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
+      slack_notify: true
+    secrets: inherit
 
   deploy-testnet-playground:
     needs: [init, dependencies]
@@ -240,3 +248,5 @@ jobs:
       healthcheck_elasticsearch_enabled: true
       healthcheck_redis_enabled: true
       serverless_deploy_prefix: explorer-svc
+      slack_notify: true
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.setenv.outputs.environment}}
+      timestamp: ${{ steps.setenv.outputs.timestamp }}
 
     steps:
       - name: Set environment

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,7 +4,7 @@ on:
     paths-ignore:
       - '**.md'
   push:
-    branches: [master, dev]
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -14,8 +14,8 @@ jobs:
         python-version: ["3.9", "3.10"]
     steps:
       - name: Checkout to branch
-        # https://github.com/actions/checkout/releases/tag/v3.5.3
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        # https://github.com/actions/checkout/releases/tag/v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python and Dependencies
         uses: ./.github/actions/setup-python
         with:


### PR DESCRIPTION
## Summary

Migrates the explorer-service CI/CD and PR templates to the new `main` / `release-candidate` / `release` git flow, following the [release process guidelines](https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/guidelines.md).

## Changes

### CI/CD

- **`deploy.yml`**: trigger branches updated to `[main]` only; `main` → dev environment; RC tags (`v*-rc*`) → testnet environments; stable tags (`v*.*.*`) → mainnet. Removed the dead `github.base_ref` conditions that only fire on PR events. Added `slack_notify: true` + `secrets: inherit` to all non-dev deploy jobs.
- **`deploy-reusable.yml`**: added `slack_notify` boolean input (default `false`) and a final Slack notification step posting to `#deploys` on completion.
- **`pr-validation.yml`**: removed stale `master` and `dev` branch refs; now only runs CI on pushes to `main`.
- **`codeql.yml`**: added `release-candidate` and `release` to the CodeQL push trigger.

### PR Templates

- Replaced the single default template with a multi-template picker (select in Preview tab).
- Added `PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md`
- Added `PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md`
- Added `PULL_REQUEST_TEMPLATE/release_pr_template.md`

## Notes

- [x] The `SLACK_WEBHOOK` secret must be added to this repository's settings (same webhook used by health-monitor).
- Companion PR in ops-tools updates the Flux image policy and adds the release guide: https://github.com/HathorNetwork/ops-tools/pull/1253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-specific PR templates (feature, release-candidate, release) and a selector to pick the right template.
  * Optional per-deploy Slack notifications via a new toggle and webhook.

* **Infrastructure & DevOps**
  * Upgraded and re-pinned CI/CD action versions; updated CodeQL and workflow triggers to better cover main, release-candidate, and release branches.
  * Streamlined deployment routing and tag-driven environment selection.

* **Documentation**
  * Standardized PR guidance with motivation, acceptance criteria, and merge/readiness checklists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-explorer-service/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->