### PR TITLE
hotfix: cache ttl must be an integer no greater than 3600

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -424,7 +424,7 @@ functions:
           cors: true
           caching:
             enabled: true
-            ttlInSeconds: 86400  # one day cache, as icons don't change often
+            ttlInSeconds: 3600 # one hour cache, the maximum allowed, as icons don't change often
             cacheKeyParameters:
               - name: request.querystring.id
               - name: request.header.origin


### PR DESCRIPTION
### Acceptance Criteria
- The API Gateway has a limit of 3600s for caching TTL


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Icon metadata cache duration updated from 24 hours to 1 hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->