### PR TITLE
feat: add has_confidential_activity flag to address/tokens response

### DIFF
--- a/gateways/clients/wallet_service_db_client.py
+++ b/gateways/clients/wallet_service_db_client.py
@@ -13,10 +13,12 @@ from common.configuration import (
     WALLET_SERVICE_DB_USERNAME,
 )
 from common.errors import RdsError, RdsNotFoundError
+from common.logging import get_logger
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine, Row
 
+logger = get_logger()
 
 address_balance_query: str = """\
 SELECT
@@ -88,6 +90,12 @@ SELECT COUNT(*) as total
 FROM token INNER JOIN address_balance
 ON token.id = address_balance.token_id
 WHERE address_balance.address = :address"""
+
+address_has_confidential_activity_query: str = """\
+SELECT EXISTS(
+    SELECT 1 FROM tx_output
+    WHERE address = :address AND mode != 0 AND voided = FALSE
+) AS has_confidential_activity"""
 
 ping_query: str = "SELECT 1"
 
@@ -201,6 +209,33 @@ class WalletServiceDBClient:
                 result.append(row._asdict())
 
         return total, result
+
+    def get_address_has_confidential_activity(self, address: str) -> bool:
+        """Whether the address has any shielded (confidential) output.
+
+        Reads `tx_output.mode` (0 = transparent, 1 = AmountShielded,
+        2 = FullShielded), a column added by the wallet-service shielded
+        migrations. If that column is not deployed yet the query raises; we
+        treat any failure as "no confidential activity" so the address page
+        keeps working (the banner is a non-critical enhancement).
+        """
+        try:
+            with self.engine.connect() as connection:
+                cursor = connection.execute(
+                    text(address_has_confidential_activity_query), address=address
+                )
+                try:
+                    result = cursor.one()
+                finally:
+                    cursor.close()
+            return bool(result._asdict()["has_confidential_activity"])
+        except Exception as exc:
+            logger.warning(
+                "confidential_activity_check_failed",
+                address=address,
+                error=repr(exc),
+            )
+            return False
 
     def ping(self, timeout: int = 5) -> Tuple[bool, dict]:
         """Ping the database to check if it's alive."""

--- a/gateways/wallet_service_gateway.py
+++ b/gateways/wallet_service_gateway.py
@@ -43,3 +43,7 @@ class WalletServiceGateway:
         total, tokens = self.db_client.get_address_tokens(address, limit, offset)
 
         return total, [TokenEntry.from_dict(token) for token in tokens]
+
+    def address_has_confidential_activity(self, address: str) -> bool:
+        """Whether the address has any shielded (confidential) output."""
+        return self.db_client.get_address_has_confidential_activity(address)

--- a/tests/unit/gateways/clients/test_wallet_service_db_client.py
+++ b/tests/unit/gateways/clients/test_wallet_service_db_client.py
@@ -8,6 +8,7 @@ from common.errors import RdsError, RdsNotFoundError
 from gateways.clients.wallet_service_db_client import (
     WalletServiceDBClient,
     address_balance_query,
+    address_has_confidential_activity_query,
     address_has_htr_query,
     address_history_query,
     address_tokens_count_query,
@@ -259,6 +260,58 @@ class TestWalletServiceDBClient:
         )
         assert connection.execute.call_args_list[1][0][0].text == address_has_htr_query
         assert connection.execute.call_args_list[2][0][0].text == address_tokens_query
+
+    def test_get_address_has_confidential_activity_true(self, engine, connection):
+        cursor = MagicMock()
+        cursor.one.return_value = self.row_from_dict({"has_confidential_activity": 1})
+        connection.execute.return_value = cursor
+
+        client = WalletServiceDBClient(engine)
+        address = "H" + fake.pystr()
+
+        assert client.get_address_has_confidential_activity(address) is True
+        connection.execute.assert_called_once_with(ANY, address=address)
+        assert (
+            connection.execute.call_args[0][0].text
+            == address_has_confidential_activity_query
+        )
+
+    def test_get_address_has_confidential_activity_false(self, engine, connection):
+        cursor = MagicMock()
+        cursor.one.return_value = self.row_from_dict({"has_confidential_activity": 0})
+        connection.execute.return_value = cursor
+
+        client = WalletServiceDBClient(engine)
+        address = "H" + fake.pystr()
+
+        assert client.get_address_has_confidential_activity(address) is False
+
+    def test_get_address_has_confidential_activity_degrades_on_error(
+        self, engine, connection
+    ):
+        # When the `mode` column does not exist yet (wallet-service shielded
+        # migrations not deployed), the query raises. The flag must degrade to
+        # False rather than break the address page.
+        connection.execute.side_effect = Exception("Unknown column 'mode'")
+
+        client = WalletServiceDBClient(engine)
+        address = "H" + fake.pystr()
+
+        assert client.get_address_has_confidential_activity(address) is False
+
+    def test_get_address_has_confidential_activity_degrades_on_cursor_error(
+        self, engine, connection
+    ):
+        # An error after execute (e.g. cursor.one() raising) must also degrade
+        # to False rather than propagate.
+        cursor = MagicMock()
+        cursor.one.side_effect = Exception("cursor failure")
+        connection.execute.return_value = cursor
+
+        client = WalletServiceDBClient(engine)
+        address = "H" + fake.pystr()
+
+        assert client.get_address_has_confidential_activity(address) is False
 
     def test_ping(self, engine, connection):
         class mockRow(list):

--- a/tests/unit/gateways/test_wallet_service.py
+++ b/tests/unit/gateways/test_wallet_service.py
@@ -78,6 +78,15 @@ class TestWalletServiceDBClient:
             address, token, limit, last_tx, last_ts
         )
 
+    def test_address_has_confidential_activity(self, db_client):
+        db_client.get_address_has_confidential_activity.return_value = True
+
+        gateway = WalletServiceGateway(db_client)
+        address = "H" + fake.pystr()
+
+        assert gateway.address_has_confidential_activity(address) is True
+        db_client.get_address_has_confidential_activity.assert_called_once_with(address)
+
     def test_address_balance(self, db_client):
         balance = TokenBalanceFactory()
         db_client.get_address_balance.return_value = balance.to_dict()

--- a/tests/unit/usecases/test_wallet_service.py
+++ b/tests/unit/usecases/test_wallet_service.py
@@ -62,6 +62,7 @@ class TestWalletService:
         objs = [TokenEntryFactory() for _ in range(fake.random_int(min=1, max=10))]
         total = fake.pyint()
         wallet_service_gateway.address_tokens.return_value = (total, objs)
+        wallet_service_gateway.address_has_confidential_activity.return_value = True
 
         addr = fake.pystr()
         limit = fake.pyint()
@@ -80,6 +81,10 @@ class TestWalletService:
         assert all(
             [ret == obj for ret, obj in zip(returned["tokens"], expected["tokens"])]
         )
+        assert returned["has_confidential_activity"] is True
         wallet_service_gateway.address_tokens.assert_called_once_with(
             addr, limit, offset
+        )
+        wallet_service_gateway.address_has_confidential_activity.assert_called_once_with(
+            addr
         )

--- a/usecases/wallet_service.py
+++ b/usecases/wallet_service.py
@@ -27,7 +27,11 @@ class WalletService:
         total, tokens = self.wallet_service_gateway.address_tokens(
             address, limit, offset
         )
+        has_confidential_activity = (
+            self.wallet_service_gateway.address_has_confidential_activity(address)
+        )
         return {
             "total": total,
             "tokens": {token.token_id: token.to_dict() for token in tokens},
+            "has_confidential_activity": has_confidential_activity,
         }


### PR DESCRIPTION
## Summary

Adds a per-address `has_confidential_activity` boolean to the `/address/tokens` response. The explorer uses it to render a "This address has confidential activity" banner and `(public)` labels on the address screen (companion frontend PR in `hathor-explorer`: surface shielded output activity on the address screen).

## What it does

- **DB client** (`gateways/clients/wallet_service_db_client.py`) — new `address_has_confidential_activity_query` + `get_address_has_confidential_activity(address) -> bool`:
  ```sql
  SELECT EXISTS(
    SELECT 1 FROM tx_output
    WHERE address = :address AND mode != 0 AND voided = FALSE
  ) AS has_confidential_activity
  ```
  Wrapped in `try/except -> False` with a `logger.warning`, so it degrades gracefully (and observably) when the `tx_output.mode` column — added by the wallet-service shielded migrations — is not deployed yet. The address page must never break on this non-critical enhancement.
- **Gateway** (`gateways/wallet_service_gateway.py`) — `address_has_confidential_activity` delegates to the DB client.
- **Usecase** (`usecases/wallet_service.py`) — `address_tokens` includes `has_confidential_activity` alongside `total`/`tokens`.

## Why values stay public-only

The wallet-service is a public indexer with no scan keys for arbitrary addresses, so it can only ever read transparent (public) amounts. This flag just signals that confidential activity exists; the aggregate balances remain public-only by construction.

## Testing

- Unit tests for all three layers (true/false, graceful degradation on a missing-column error, and on a post-execute cursor error).
- Full suite: 213 passed, coverage 91.83% (gate ≥90%). black/isort/mypy clean.

## Deployment note

The `tx_output.mode` column lands with the wallet-service shielded stack (#439–#447). Until then, `has_confidential_activity` is always `false` (graceful fallback) and the frontend behaves exactly as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to detect whether a wallet address has confidential/shielded activity
  * Address token queries now include confidential activity status in responses

* **Tests**
  * Added comprehensive test coverage for confidential activity detection, including error handling scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->